### PR TITLE
always show organization and visibility in package form

### DIFF
--- a/ckanext/scheming/templates/scheming/form_snippets/organization.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/organization.html
@@ -1,23 +1,13 @@
 {# This is specific to datasets' owner_org field and won't work #}
 {# if used with other fields #}
 
-{# if we have a default group then this wants remembering #}
-{% if data.group_id %}
-  <input type="hidden" name="groups__0__id" value="{{ data.group_id }}" />
-{% endif %}
-
 {% set dataset_is_draft = data.get('state', 'draft').startswith('draft') or data.get('state', 'none') ==  'none' %}
 {% set dataset_has_organization = data.owner_org or data.group_id %}
 {% set organizations_available = h.organizations_available('create_dataset') %}
 {% set user_is_sysadmin = h.check_access('sysadmin') %}
-{% set show_organizations_selector = organizations_available and (user_is_sysadmin or dataset_is_draft) %}
-{% set show_visibility_selector = dataset_has_organization or (organizations_available and (user_is_sysadmin or dataset_is_draft)) %}
 
-{% if show_organizations_selector and show_visibility_selector %}
   <div data-module="dataset-visibility">
-{% endif %}
 
-{% if show_organizations_selector %}
   {% set existing_org = data.owner_org or data.group_id %}
   <div class="control-group">
     <label for="field-organizations" class="control-label">{{
@@ -29,14 +19,13 @@
         {% endif %}
         {% for organization in organizations_available %}
           {# get out first org from users list only if there is not an existing org #}
-          {% set selected_org = (existing_org and existing_org == organization.id) or (not existing_org and not data.id and organization.id == organizations_available[0].id) %}
+          {% set selected_org = (existing_org and existing_org == organization.id) or (
+            not existing_org and not data.id and organization.id == organizations_available[0].id) %}
           <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ organization.name }}</option>
         {% endfor %}
       </select>
     </div>
   </div>
-{% endif %}
-{% if show_visibility_selector %}
   {% block package_metadata_fields_visibility %}
     <div class="control-group">
       <label for="field-private" class="control-label">{{ _('Visibility') }}</label>
@@ -49,8 +38,5 @@
       </div>
     </div>
   {% endblock %}
-{% endif %}
 
-{% if show_organizations_selector and show_visibility_selector %}
   </div>
-{% endif %}


### PR DESCRIPTION
Re #19 and as advised by @wardi, this removes the conditional hiding of organization and visibility selector, thus always giving the user with 'package update' privileges the options to select organization and visibility. This PR opens up the originally more restricted permissions with the reasoning that if a user is permitted to update package metadata, the user should also be permitted to transfer ownership between the user's organizations, and also to toggle visibility.
