### PR TITLE
snippets: pass entity_type+object_type instead of whole schema

### DIFF
--- a/ckanext/scheming/templates/scheming/form_snippets/slug.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/slug.html
@@ -1,6 +1,6 @@
 {% import 'macros/form.html' as form %}
 
-{%- entity_type == 'dataset' %}
+{%- if entity_type == 'dataset' %}
     {%- set controller = 'package' -%}
     {%- set module_placeholder = '<dataset>' -%}
 {%- elif entity_type == 'organization' %}

--- a/ckanext/scheming/templates/scheming/form_snippets/slug.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/slug.html
@@ -1,12 +1,12 @@
 {% import 'macros/form.html' as form %}
 
-{%- if 'dataset_type' in schema %}
+{%- entity_type == 'dataset' %}
     {%- set controller = 'package' -%}
     {%- set module_placeholder = '<dataset>' -%}
-{%- elif 'organization_type' in schema %}
+{%- elif entity_type == 'organization' %}
     {%- set controller = 'organization' -%}
     {%- set module_placeholder = '<organization>' -%}
-{%- elif 'group_type' in schema -%}
+{%- elif entity_type == 'group' -%}
     {%- set controller = 'group' -%}
     {%- set module_placeholder = '<group>' -%}
 {%- endif -%}

--- a/ckanext/scheming/templates/scheming/group/group_form.html
+++ b/ckanext/scheming/templates/scheming/group/group_form.html
@@ -10,7 +10,7 @@
     {%- for field in schema['fields'] -%}
         {%- snippet 'scheming/snippets/form_field.html',
         field=field, data=data, errors=errors, licenses=licenses,
-        schema=schema -%}
+        entity_type='group', object_type=c.group_type -%}
     {%- endfor -%}
 
     <div class="form-actions">

--- a/ckanext/scheming/templates/scheming/organization/group_form.html
+++ b/ckanext/scheming/templates/scheming/organization/group_form.html
@@ -10,7 +10,7 @@
     {%- for field in schema['fields'] -%}
         {%- snippet 'scheming/snippets/form_field.html',
         field=field, data=data, errors=errors, licenses=licenses,
-        schema=schema -%}
+        entity_type='organization', object_type=c.group_type -%}
     {%- endfor -%}
 
     <div class="form-actions">

--- a/ckanext/scheming/templates/scheming/package/resource_read.html
+++ b/ckanext/scheming/templates/scheming/package/resource_read.html
@@ -52,7 +52,8 @@
                 </th>
                 <td>
                   {%- snippet 'scheming/snippets/display_field.html',
-                      field=field, data=res, schema=schema -%}
+                      field=field, data=res, entity_type='dataset',
+                      object_type=dataset_type -%}
                 </td>
               </tr>
             {%- endif -%}

--- a/ckanext/scheming/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/package_form.html
@@ -4,7 +4,8 @@
   {%- if errors -%}
     {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
     {%- snippet 'scheming/snippets/errors.html',
-      errors=errors, fields=schema.dataset_fields, schema=schema -%}
+      errors=errors, fields=schema.dataset_fields,
+      entity_type='dataset', object_type=dataset_type -%}
   {%- endif -%}
 {% endblock %}
 
@@ -20,7 +21,7 @@
     {%- if field.form_snippet is not none -%}
       {%- snippet 'scheming/snippets/form_field.html',
         field=field, data=data, errors=errors, licenses=c.licenses,
-        schema=schema -%}
+        entity_type='dataset', object_type=dataset_type -%}
     {%- endif -%}
   {%- endfor -%}
   {%- if 'resource_fields' not in schema -%}

--- a/ckanext/scheming/templates/scheming/package/snippets/resource_form.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/resource_form.html
@@ -4,7 +4,8 @@
   {%- if errors -%}
     {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
     {%- snippet 'scheming/snippets/errors.html',
-      errors=errors, fields=schema.resource_fields, schema=schema -%}
+      errors=errors, fields=schema.resource_fields,
+      entity_type='dataset', object_type=dataset_type -%}
   {%- endif -%}
 {% endblock %}
 
@@ -18,7 +19,8 @@
   {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
   {%- for field in schema.resource_fields -%}
     {%- snippet 'scheming/snippets/form_field.html',
-      field=field, data=data, errors=errors, schema=schema -%}
+      field=field, data=data, errors=errors,
+      entity_type='dataset', object_type=dataset_type -%}
   {%- endfor -%}
 {% endblock %}
 

--- a/ckanext/scheming/templates/scheming/snippets/display_field.html
+++ b/ckanext/scheming/templates/scheming/snippets/display_field.html
@@ -17,5 +17,5 @@
 
 {%- if field.field_name in data -%}
   {%- snippet display_snippet, field=field, data=data, errors=errors,
-    schema=schema -%}
+    entity_type=entity_type, object_type=object_type -%}
 {%- endif -%}

--- a/ckanext/scheming/templates/scheming/snippets/errors.html
+++ b/ckanext/scheming/templates/scheming/snippets/errors.html
@@ -16,7 +16,8 @@
           {%- endif -%}
 
           {%- snippet error_snippet, unprocessed=unprocessed,
-            field=field, fields=fields, schema=schema -%}
+            field=field, fields=fields,
+            entity_type=entity_type, object_type=object_type -%}
         {%- endif -%}
 
         {%- if field.field_name in unprocessed -%}

--- a/ckanext/scheming/templates/scheming/snippets/form_field.html
+++ b/ckanext/scheming/templates/scheming/snippets/form_field.html
@@ -12,4 +12,4 @@
 {%- endif -%}
 
 {%- snippet form_snippet, field=field, data=data, errors=errors,
-  licenses=licenses, schema=schema -%}
+  licenses=licenses, entity_type=entity_type, object_type=object_type -%}


### PR DESCRIPTION
This solves a really nasty performance issue with tens/hundreds of thousands of calls to safe_repr when running in debug mode.