### PR TITLE
fix the order of choices for PR 106

### DIFF
--- a/ckanext/scheming/templates/scheming/form_snippets/multiple_checkbox.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/multiple_checkbox.html
@@ -19,18 +19,16 @@ fieldset.checkboxes label input {
     classes=['control-medium'],
     error=errors[field.field_name],
     is_required=h.scheming_field_required(field)) -%}
-  {%- set localized_choices = {} -%}
+  {%- set localized_choices = [] -%}
   {%- for choice in field.choices -%}
-    {%- do localized_choices.update(
-        {choice.value:h.scheming_language_text(choice.label)}) -%}
+    {%- do localized_choices.append(
+        (h.scheming_language_text(choice.label), choice.value)) -%}
   {%- endfor -%}
   {%- if field.get('sorted_choices') -%}
-    {%- set localized_choices = localized_choices|dictsort(false, 'value') -%}
-  {%- else -%}
-    {%- set localized_choices = localized_choices.iteritems() %}
+    {%- set localized_choices = localized_choices|sort -%}
   {%- endif -%}
     <fieldset class="checkboxes">
-        {%- for c, v in localized_choices -%}
+        {%- for v, c in localized_choices -%}
             <label for="field-{{ field.field_name }}-{{ c }}">
                 <input id="field-{{ field.field_name }}-{{ c }}"
                     type="checkbox"

--- a/ckanext/scheming/templates/scheming/form_snippets/multiple_select.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/multiple_select.html
@@ -6,22 +6,20 @@
     classes=['control-medium'],
     error=errors[field.field_name],
     is_required=h.scheming_field_required(field)) -%}
-  {%- set localized_choices = {} -%}
+  {%- set localized_choices = [] -%}
   {%- for choice in field.choices -%}
-    {%- do localized_choices.update(
-        {choice.value:h.scheming_language_text(choice.label)}) -%}
+    {%- do localized_choices.append(
+        (h.scheming_language_text(choice.label), choice.value)) -%}
   {%- endfor -%}
   {%- if field.get('sorted_choices') -%}
-    {%- set localized_choices = localized_choices|dictsort(false, 'value') -%}
-  {%- else -%}
-    {%- set localized_choices = localized_choices.iteritems() %}
+    {%- set localized_choices = localized_choices|sort -%}
   {%- endif -%}
   <select multiple
       size="{{ ([field.get('select_size', 10), field.choices|length]|sort)[0] }}"
       style="display: block"
       id="field-{{ field.field_name }}"
       name="{{ field.field_name }}" >
-    {%- for c, v in localized_choices -%}
+    {%- for v, c in localized_choices -%}
       <option id="field-{{ field.field_name }}-{{ c }}"
           value="{{ c }}"
           {{"selected " if c in data[field.field_name] }} />

--- a/ckanext/scheming/templates/scheming/form_snippets/select.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/select.html
@@ -4,17 +4,15 @@
 {%- if not h.scheming_field_required(field) -%}
     {%- do options.append({'value': ''}) -%}
 {%- endif -%}
-{%- set localized_choices = {} -%}
+{%- set localized_choices = [] -%}
 {%- for choice in field.choices -%}
-    {%- do localized_choices.update(
-        {choice.value:h.scheming_language_text(choice.label)}) -%}
+    {%- do localized_choices.append(
+        (h.scheming_language_text(choice.label), choice.value)) -%}
 {%- endfor -%}
 {%- if field.get('sorted_choices') -%}
-    {%- set localized_choices = localized_choices|dictsort(false, 'value') -%}
-{%- else -%}
-    {%- set localized_choices = localized_choices.iteritems() %}
+    {%- set localized_choices = localized_choices|sort -%}
 {%- endif -%}
-{%- for c, v in localized_choices -%}
+{%- for v, c in localized_choices -%}
     {%- do options.append({
         'value': c,
         'text': v}) -%}


### PR DESCRIPTION
the changes I made in PR 106 didn't render choices in the order
they were listed in the schema when sorted_choices was not set
to true.  this update should fix that