### PR TITLE
use ckantoolkit

### DIFF
--- a/ckanext/scheming/commands.py
+++ b/ckanext/scheming/commands.py
@@ -1,4 +1,4 @@
-from ckan.lib.cli import CkanCommand
+from ckantoolkit import CkanCommand
 import paste.script
 
 from ckanext.scheming.helpers import (

--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -1,6 +1,7 @@
-from ckantoolkit import h, _ as gettext
+from ckantoolkit import h
 
 from pylons import config
+from pylons.i18n import gettext
 
 lang = h.lang
 

--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -1,7 +1,8 @@
-from ckan.lib.helpers import lang
-from pylons import config
-from pylons.i18n import gettext
+from ckantoolkit import h, _ as gettext
 
+from pylons import config
+
+lang = h.lang
 
 def scheming_language_text(text, prefer_lang=None):
     """

--- a/ckanext/scheming/logic.py
+++ b/ckanext/scheming/logic.py
@@ -1,4 +1,4 @@
-from ckan.plugins.toolkit import get_or_bust, side_effect_free, ObjectNotFound
+from ckantoolkit import get_or_bust, side_effect_free, ObjectNotFound
 
 from ckanext.scheming.helpers import (
     scheming_dataset_schemas, scheming_get_dataset_schema,

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -5,11 +5,11 @@ import ckan.plugins as p
 from ckantoolkit import (
     DefaultDatasetForm,
     DefaultGroupForm,
-    DefaultOrganizationForm
+    DefaultOrganizationForm,
     get_validator,
     get_converter,
     navl_validate,
-    add_template_directory
+    add_template_directory,
 )
 
 from paste.reloader import watch_file

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -2,12 +2,10 @@
 # encoding: utf-8
 from pylons import c
 import ckan.plugins as p
-from ckan.lib.plugins import (
+from ckantoolkit import (
     DefaultDatasetForm,
     DefaultGroupForm,
     DefaultOrganizationForm
-)
-from ckan.plugins.toolkit import (
     get_validator,
     get_converter,
     navl_validate,

--- a/ckanext/scheming/tests/test_dataset_display.py
+++ b/ckanext/scheming/tests/test_dataset_display.py
@@ -1,7 +1,7 @@
 from nose.tools import assert_true
 
-from ckan.tests.factories import Sysadmin, Dataset
-from ckan.tests.helpers import FunctionalTestBase, submit_and_follow
+from ckantoolkit.tests.factories import Sysadmin, Dataset
+from ckantoolkit.tests.helpers import FunctionalTestBase, submit_and_follow
 
 
 class TestDatasetDisplay(FunctionalTestBase):

--- a/ckanext/scheming/tests/test_form.py
+++ b/ckanext/scheming/tests/test_form.py
@@ -1,8 +1,8 @@
 from nose import SkipTest
 from nose.tools import assert_true
 
-from ckan.tests.factories import Sysadmin
-from ckan.tests.helpers import FunctionalTestBase, submit_and_follow
+from ckantoolkit.tests.factories import Sysadmin
+from ckantoolkit.tests.helpers import FunctionalTestBase, submit_and_follow
 
 def _get_package_new_page_as_sysadmin(app):
     user = Sysadmin()

--- a/ckanext/scheming/tests/test_group_display.py
+++ b/ckanext/scheming/tests/test_group_display.py
@@ -1,7 +1,7 @@
 from nose.tools import assert_true
 
-from ckan.tests.factories import Sysadmin, Organization, Group
-from ckan.tests.helpers import FunctionalTestBase
+from ckantoolkit.tests.factories import Sysadmin, Organization, Group
+from ckantoolkit.tests.helpers import FunctionalTestBase
 
 
 class TestOrganizationDisplay(FunctionalTestBase):

--- a/ckanext/scheming/tests/test_validation.py
+++ b/ckanext/scheming/tests/test_validation.py
@@ -7,7 +7,7 @@ from ckanext.scheming.errors import SchemingException
 from ckanext.scheming.validation import get_validator_or_converter, scheming_required
 from ckanext.scheming.plugins import (
     SchemingDatasetsPlugin, SchemingGroupsPlugin)
-from ckan.plugins.toolkit import get_validator
+from ckantoolkit import get_validator
 
 ignore_missing = get_validator('ignore_missing')
 not_empty = get_validator('not_empty')

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -3,7 +3,7 @@ import datetime
 import re
 import ckan.lib.helpers as h
 
-from ckan.plugins.toolkit import get_validator, UnknownValidator, missing, Invalid, _
+from ckantoolkit import get_validator, UnknownValidator, missing, Invalid, _
 
 from ckanext.scheming.errors import SchemingException
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ckanapi
+ckantoolkit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ckanapi
-ckantoolkit
+ckantoolkit>=0.0.2


### PR DESCRIPTION
ckan has recently added all the internal attributes we've been importing to its plugin toolkit. ckantoolkit lets us use those attributes even with older versions of ckan.