### PR TITLE
enable tag vocabularies

### DIFF
--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -52,6 +52,10 @@ def scheming_choices_label(choices, value):
     the value passed when not found. Result is passed through
     scheming_language_text before being returned.
     """
+    try:    # value might by a single element list
+        value = value.pop() if value else ''
+    except AttributeError:
+        pass
     for c in choices:
         if c['value'] == value:
             return scheming_language_text(c['label'])

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -91,7 +91,7 @@ class _SchemingMixin(object):
             'scheming_field_by_name': helpers.scheming_field_by_name,
             'scheming_get_presets': helpers.scheming_get_presets,
             'scheming_get_preset': helpers.scheming_get_preset,
-            'scheming_get_schema': helpers.scheming_get_schema
+            'scheming_get_schema': helpers.scheming_get_schema,
             }
 
     def get_validators(self):

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -27,7 +27,7 @@ def scheming_choices(field, schema):
     """
     Require that one of the field choices values is passed.
     """
-    return OneOf([c['value'] for c in field['choices']])
+    return OneOf([c['value'] for c in field['choices']], testValueList=True)
 
 
 @scheming_validator
@@ -80,8 +80,10 @@ def scheming_multiple_choice(field, schema):
             errors[key].append(_('unexpected choice "%s"') % element)
 
         if not errors[key]:
-            data[key] = json.dumps([
-                c['value'] for c in field['choices'] if c['value'] in selected])
+            if 'vocabulary' not in field:
+                data[key] = json.dumps([
+                    c['value'] for c in field['choices']
+                    if c['value'] in selected])
 
             if field.get('required') and not selected:
                 errors[key].append(_('Select at least one'))

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -27,7 +27,7 @@ def scheming_choices(field, schema):
     """
     Require that one of the field choices values is passed.
     """
-    return OneOf([c['value'] for c in field['choices']], testValueList=True)
+    return OneOf([c['value'] for c in field['choices']])
 
 
 @scheming_validator


### PR DESCRIPTION
+ provides the property `"vocabulary"`, the value of which is the name of the vocabulary.    
    Example:

 ```javascript
{
   "field_name": "systems",
   "label": "Systems",
   "preset": "multiple_select",
   "vocabulary": "systems",
   "required": true
 },
```

+ provides the property `"free_tags_only"` in the top level of the schema definition. `"free_tags_only": true` will prevent vocabulary tags from being listed in the free tags' display.

+ Currently tested with presets `select` and `multiple_select`.
  