### PR TITLE
Explicity require pytz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ckanapi
 ckantoolkit>=0.0.2
+pytz

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     install_requires=[
         "ckanapi",
         "ckantoolkit>=0.0.2",
+        "pytz",
     ],
     entry_points=\
     """


### PR DESCRIPTION
Required for older versions of CKAN that don't include pytz