### PR TITLE
Update resource_form.html

### DIFF
--- a/ckanext/scheming/templates/scheming/package/snippets/resource_form.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/resource_form.html
@@ -1,4 +1,5 @@
 {% extends 'package/snippets/resource_form.html' %}
+{% import 'macros/form.html' as form %}
 
 {% block errors %}
   {%- if errors -%}
@@ -6,6 +7,8 @@
     {%- snippet 'scheming/snippets/errors.html',
       errors=errors, fields=schema.resource_fields,
       entity_type='dataset', object_type=dataset_type -%}
+  {%- elif error_summary -%}
+    {{ form.errors(error_summary) }}
   {%- endif -%}
 {% endblock %}
 


### PR DESCRIPTION
When I try to create a dataset with no resources, the error 'You must add at least one data resource' does not appear in the resource_form. When I analyzed lines 656 to 668 in https://github.com/ckan/ckan/blob/master/ckan/controllers/package.py#L656-L668 , I realized that the error dict is empty and only the error_summary is assigned the message. That is why I suggest checking and adding the error summary in this scheming snippet as well. I tried to extend this snippet otherwise, but I didn't succeed. With this patch, I got the error message to reappear on the page.