### PR TITLE
Use the choices list to determine size of select field

### DIFF
--- a/ckanext/scheming/templates/scheming/form_snippets/multiple_select.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/multiple_select.html
@@ -15,7 +15,7 @@
     {%- set choices = choices|sort(case_sensitive=false, attribute=1) -%}
   {%- endif -%}
   <select multiple
-      size="{{ ([field.get('select_size', 10), field.choices|length]|sort)[0] }}"
+      size="{{ ([field.get('select_size', 10), choices|length]|sort)[0] }}"
       style="display: block"
       id="field-{{ field.field_name }}"
       name="{{ field.field_name }}" >


### PR DESCRIPTION
The previous code only works if you define a list of values in your
schema JSON. For the new choices_helper options, where field.choices is
not set, the size would always be set to 0.

This change uses the correct choices list to determine the correct size
of the select field.