### PR TITLE
Upgrade pytz to match ckan 2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ckanapi
 ckantoolkit>=0.0.2
-pytz==2012j
+pytz==2016.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ckanapi
 ckantoolkit>=0.0.2
-pytz==2016.4
+pytz


### PR DESCRIPTION
CKAN core upgraded pytz and install will complain about version conflict.