### PR TITLE
Bump pytz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ckanapi
 ckantoolkit>=0.0.2
-pytz==2012j
+pytz==2016.7


### PR DESCRIPTION
This will make the extension work properly with CKAN 2.6.0 by using the same pytz version with the one installed on CKAN 2.6.0