### PR TITLE
Switch to jinja2 macros.

### DIFF
--- a/ckanext/scheming/templates/scheming/display_snippets/date.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/date.html
@@ -1,3 +1,5 @@
+{%- macro display(h, field, data, errors, entity_type, object_type) -%}
 {% if data[field.field_name] %}
   {{ data[field.field_name].split()[0] }}
 {% endif %}
+{%- endmacro -%}

--- a/ckanext/scheming/templates/scheming/display_snippets/datetime.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/datetime.html
@@ -1,1 +1,3 @@
-{% extends 'scheming/display_snippets/text.html' %}
+{%- macro display(h, field, data, errors, entity_type, object_type) -%}
+{{ data[field.field_name] }}
+{%- endmacro -%}

--- a/ckanext/scheming/templates/scheming/display_snippets/datetime_tz.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/datetime_tz.html
@@ -1,1 +1,3 @@
+{%- macro display(h, field, data, errors, entity_type, object_type) -%}
 {{ h.render_datetime(data[field.field_name], date_format='%Y-%m-%d %H:%M %Z') }}
+{%- endmacro -%}

--- a/ckanext/scheming/templates/scheming/display_snippets/email.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/email.html
@@ -1,3 +1,5 @@
+{%- macro display(h, field, data, errors, entity_type, object_type) -%}
 {{ h.mail_to(email_address=data[field.field_name],
    name=data[field.display_email_name_field] if field.display_email_name_field
    else None) }}
+{%- endmacro -%}

--- a/ckanext/scheming/templates/scheming/display_snippets/link.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/link.html
@@ -1,1 +1,3 @@
+{%- macro display(h, field, data, errors, entity_type, object_type) -%}
 {{ h.link_to(data[field.field_name], data[field.field_name], rel=field.display_property, target='_blank') }}
+{%- endmacro -%}

--- a/ckanext/scheming/templates/scheming/display_snippets/multiple_choice.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/multiple_choice.html
@@ -1,3 +1,4 @@
+{%- macro display(h, field, data, errors, entity_type, object_type) -%}
 {%- set values = data[field.field_name] -%}
 {%- set labels = [] -%}
 
@@ -19,3 +20,4 @@
     {%- endfor -%}
     </ul>
 {%- endif -%}
+{%- endmacro -%}

--- a/ckanext/scheming/templates/scheming/display_snippets/select.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/select.html
@@ -1,3 +1,5 @@
+{%- macro display(h, field, data, errors, entity_type, object_type) -%}
 {{ h.scheming_choices_label(
   h.scheming_field_choices(field),
   data[field.field_name]) }}
+{%- endmacro -%}

--- a/ckanext/scheming/templates/scheming/display_snippets/text.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/text.html
@@ -1,1 +1,3 @@
+{%- macro display(h, field, data, errors, entity_type, object_type) -%}
 {{ data[field.field_name] }}
+{%- endmacro -%}

--- a/ckanext/scheming/templates/scheming/snippets/display_field.html
+++ b/ckanext/scheming/templates/scheming/snippets/display_field.html
@@ -16,6 +16,6 @@
 {%- endif -%}
 
 {%- if field.field_name in data -%}
-  {%- snippet display_snippet, field=field, data=data, errors=errors,
-    entity_type=entity_type, object_type=object_type -%}
+  {% from display_snippet import display %}
+  {{ display(h=h, field=field, data=data, errors=errors, entity_type=entity_type, object_type=object_type) }}
 {%- endif -%}


### PR DESCRIPTION
Macros (when used without `with context`) are cached. Includes/snippets/macros[with context]) are not. When displaying many fields on many pages with high read counts this is significant CPU overhead.

This *only* changes *display* templates for minimal user-impact. Any user-defined templates can be updated by wrapping their existing template in:

```python
{%- macro display(h, field, data, errors, entity_type, object_type) -%}
<existing file>
{%- endmacro -%}
```