### PR TITLE
Show email address if field.display_email_name_field not defined

### DIFF
--- a/ckanext/scheming/templates/scheming/display_snippets/email.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/email.html
@@ -1,3 +1,3 @@
 {{ h.mail_to(email_address=data[field.field_name],
    name=data[field.display_email_name_field] if field.display_email_name_field
-   else None) }}
+   else data[field.field_name]) }}


### PR DESCRIPTION
I'm not sure what field.display_email_name_field is or is or how to use it from a schema, but showing "None" is very confusing, at least for developers who thought they had an email address in there :-)