### PR TITLE
Update form input classes for Bootstrap 3 support

### DIFF
--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -9,7 +9,8 @@
         "validators": "if_empty_same_as(name) unicode",
         "form_snippet": "large_text.html",
         "form_attrs": {
-          "data-module": "slug-preview-target"
+          "data-module": "slug-preview-target",
+          "class": "form-control"
         }
       }
     },
@@ -24,6 +25,7 @@
       "preset_name": "tag_string_autocomplete",
       "values": {
         "validators": "ignore_missing tag_string_convert",
+        "classes": ["control-full"],
         "form_attrs": {
           "data-module": "autocomplete",
           "data-module-tags": "",

--- a/ckanext/scheming/templates/scheming/form_snippets/_organization_select.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/_organization_select.html
@@ -9,6 +9,7 @@ not used as a form_snippet directly #}
     label=h.scheming_language_text(field.label),
     error=errors[field.field_name],
     is_required=org_required,
+    classes=['form-group', 'control-medium'],
     extra_html=caller() if caller,
     ) %}
     <div {{

--- a/ckanext/scheming/templates/scheming/form_snippets/date.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/date.html
@@ -8,7 +8,7 @@
     value=data.get(field.field_name, '').split()[0],
     error=errors[field.field_name],
     classes=['control-medium'],
-    attrs=field.form_attrs if 'form_attrs' in field else {},
+    attrs=field.form_attrs if 'form_attrs' in field else {"class": "form-control"},
     is_required=h.scheming_field_required(field)
     )
 %}

--- a/ckanext/scheming/templates/scheming/form_snippets/datetime.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/datetime.html
@@ -19,7 +19,7 @@
     value=date,
     error=errors[field.field_name + '_date'],
     classes=['control-medium'],
-    attrs=field.form_attrs if 'form_attrs' in field else {},
+    attrs=field.form_attrs if 'form_attrs' in field else {"class": "form-control"},
     is_required=h.scheming_field_required(field)
     )
 %}
@@ -34,7 +34,7 @@
     value=time,
     error=errors[field.field_name + '_time'],
     classes=['control-medium'],
-    attrs=field.form_attrs if 'form_attrs' in field else {},
+    attrs=field.form_attrs if 'form_attrs' in field else {"class": "form-control"},
     is_required=h.scheming_field_required(field)
     )
 %}

--- a/ckanext/scheming/templates/scheming/form_snippets/datetime_tz.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/datetime_tz.html
@@ -24,7 +24,7 @@
     value=date,
     error=errors[field.field_name + '_date'],
     classes=['control-medium'],
-    attrs=field.form_attrs if 'form_attrs' in field else {},
+    attrs=field.form_attrs if 'form_attrs' in field else {"class": "form-control"},
     is_required=h.scheming_field_required(field)
     )
 %}
@@ -39,7 +39,7 @@
     value=time,
     error=errors[field.field_name + '_time'],
     classes=['control-medium'],
-    attrs=field.form_attrs if 'form_attrs' in field else {},
+    attrs=field.form_attrs if 'form_attrs' in field else {"class": "form-control"},
     is_required=h.scheming_field_required(field)
     )
 %}
@@ -55,7 +55,7 @@
     selected=tz,
     error=errors[field.field_name + '_tz'],
     classes=['control-medium'],
-    attrs=field.form_attrs if 'form_attrs' in field else {},
+    attrs=field.form_attrs if 'form_attrs' in field else {"class": "form-control"},
     is_required=h.scheming_field_required(field)
     )
 %}

--- a/ckanext/scheming/templates/scheming/form_snippets/large_text.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/large_text.html
@@ -8,7 +8,7 @@
     value=data[field.field_name],
     error=errors[field.field_name],
     classes=['control-full', 'control-large'],
-    attrs=field.form_attrs if 'form_attrs' in field else {},
+    attrs=field.form_attrs if 'form_attrs' in field else {"class": "form-control"},
     is_required=h.scheming_field_required(field)
     )
 %}

--- a/ckanext/scheming/templates/scheming/form_snippets/large_text.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/large_text.html
@@ -10,7 +10,7 @@
     classes=['control-full', 'control-large'],
     attrs=field.form_attrs if 'form_attrs' in field else {},
     is_required=h.scheming_field_required(field)
-    ) 
+    )
 %}
     {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
 {% endcall %}

--- a/ckanext/scheming/templates/scheming/form_snippets/license.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/license.html
@@ -25,7 +25,9 @@
     selected=data.get(field.field_name, field.get('default', 'notspecified')),
     error=errors[field.field_name],
     classes=['control-medium'],
-    attrs=field.form_attrs if 'form_attrs' in field else {},
+    attrs=field.form_attrs if 'form_attrs' in field else {
+      "data-module": "autocomplete"
+    },
     is_required=h.scheming_field_required(field),
     )
 %}

--- a/ckanext/scheming/templates/scheming/form_snippets/markdown.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/markdown.html
@@ -7,9 +7,9 @@
     placeholder=h.scheming_language_text(field.form_placeholder),
     value=data[field.field_name],
     error=errors[field.field_name],
-    attrs=field.form_attrs or {},
+    attrs=field.form_attrs or {"class": "form-control"},
     is_required=h.scheming_field_required(field)
-    ) 
+    )
 %}
     {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
 {% endcall %}

--- a/ckanext/scheming/templates/scheming/form_snippets/multiple_select.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/multiple_select.html
@@ -7,7 +7,7 @@
 {%- call form.input_block(
     "field-{{ field.field_name }}",
     label=h.scheming_language_text(field.label),
-    classes=['control-medium'],
+    classes=['control-full'],
     error=errors[field.field_name],
     is_required=h.scheming_field_required(field),
     extra_html=help_text()

--- a/ckanext/scheming/templates/scheming/form_snippets/organization.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/organization.html
@@ -21,10 +21,10 @@
     organization_option_tag=organization_option_tag %}
 
   {% block package_metadata_fields_visibility %}
-    <div class="control-group">
+    <div class="control-group form-group control-medium">
       <label for="field-private" class="control-label">{{ _('Visibility') }}</label>
       <div class="controls">
-        <select id="field-private" name="private">
+        <select id="field-private" name="private" class="form-control">
           {% for option in [('True', _('Private')), ('False', _('Public'))] %}
           <option value="{{ option[0] }}" {% if option[0] == data.private|trim %}selected="selected"{% endif %}>{{ option[1] }}</option>
           {% endfor %}

--- a/ckanext/scheming/templates/scheming/form_snippets/select.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/select.html
@@ -25,7 +25,7 @@
     selected=data[field.field_name],
     error=errors[field.field_name],
     classes=['control-medium'],
-    attrs=field.form_attrs if 'form_attrs' in field else {},
+    attrs=field.form_attrs if 'form_attrs' in field else {"class": "form-control"},
     is_required=h.scheming_field_required(field)
     )
 %}

--- a/ckanext/scheming/templates/scheming/form_snippets/text.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/text.html
@@ -7,8 +7,8 @@
     placeholder=h.scheming_language_text(field.form_placeholder),
     value=data[field.field_name],
     error=errors[field.field_name],
-    classes=['control-medium'],
-    attrs=field.form_attrs if 'form_attrs' in field else {},
+    classes=field.classes if 'classes' in field else ['control-medium'],
+    attrs=field.form_attrs if 'form_attrs' in field else {"class": "form-control"},
     is_required=h.scheming_field_required(field)
     )
 %}

--- a/ckanext/scheming/templates/scheming/form_snippets/textarea.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/textarea.html
@@ -1,0 +1,15 @@
+{% import 'macros/form.html' as form %}
+
+{% call form.textarea(
+    field.field_name,
+    id='field-' + field.field_name,
+    label=h.scheming_language_text(field.label),
+    placeholder=h.scheming_language_text(field.form_placeholder),
+    value=data[field.field_name],
+    error=errors[field.field_name],
+    attrs=field.form_attrs or {"class": "form-control"},
+    is_required=h.scheming_field_required(field),
+    )
+%}
+    {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+{% endcall %}


### PR DESCRIPTION
This change follows the direct approach of adding the missing classes in all circumstances, both on BS2 and BS3 (ie no selective rendering). It looks mostly identical but it could potentially clash with existing
themes.

For reference here how the form is rendered with the BS3 classes in both versions (the only difference is the select input lengths in BS2 with and without scheming).

WDYT @wardi? Should this be safe enough or is it worth selectively loading depending on the BS version used? (either two full sets of snippets :scream:, or just one set of snippets with a helper and conditionals all over the place? :scream: )

If you are happy with this approach I'll update the resource fields.

### Default theme in Bootstrap 3
![localhost-5000-dataset-new 1](https://user-images.githubusercontent.com/200230/30209595-c909dc92-9490-11e7-90c5-73c131f46b8e.png)

### Default theme in Bootstrap 3 + Scheming
![localhost-5000-dataset-new](https://user-images.githubusercontent.com/200230/30209598-cd8181f8-9490-11e7-87ed-5ae43393a47d.png)

### Default theme in Bootstrap 2
![localhost-5000-dataset-new 3](https://user-images.githubusercontent.com/200230/30209601-d2c23734-9490-11e7-85e1-bebeeadac2cc.png)

### Default theme in Bootstrap 2 + Scheming
![localhost-5000-dataset-new 2](https://user-images.githubusercontent.com/200230/30209608-d7a13f8e-9490-11e7-9000-85a84d7eec00.png)
