### PR TITLE
Implementation of the json preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ This extension includes the following presets:
   field
 * `"resource_format_autocomplete"` - resource format validation with
   format guessing based on url and autocompleting form field
+* `"json"` - JSON based input. Only JSON objects and arrays are supported.
+  The input JSON will be loaded during output (eg when loading the dataset in
+  a template or via the API).
+
 
 You may add your own presets by adding them to the `scheming.presets`
 configuration setting.

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ This extension includes the following presets:
   field
 * `"resource_format_autocomplete"` - resource format validation with
   format guessing based on url and autocompleting form field
-* `"json"` - JSON based input. Only JSON objects and arrays are supported.
+* `"json_object"` - JSON based input. Only JSON objects are supported.
   The input JSON will be loaded during output (eg when loading the dataset in
   a template or via the API).
 

--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -339,6 +339,6 @@ def scheming_display_json_value(value, indent=2):
     :rtype: string
     """
     try:
-        return json.dumps(value, indent=indent)
+        return json.dumps(value, indent=indent, sort_keys=True)
     except (TypeError, ValueError):
         return value

--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -1,17 +1,20 @@
 import re
 import datetime
 import pytz
+import json
 
 from pylons import config
 from pylons.i18n import gettext
 
 from ckanapi import LocalCKAN, NotFound, NotAuthorized
 
+
 def lang():
     # access this function late in case ckan
     # is not set up fully when importing this module
     from ckantoolkit import h
     return h.lang()
+
 
 def scheming_language_text(text, prefer_lang=None):
     """
@@ -324,3 +327,18 @@ def scheming_get_timezones(field):
         return to_options(validate_tz(timezones))
 
     return to_options(pytz.common_timezones)
+
+
+def scheming_display_json_value(value, indent=2):
+    """
+    Returns the object passed serialized as a JSON string.
+
+    :param value: The object to serialize.
+    :returns: The serialized object, or the original value if it could not be
+        serialized.
+    :rtype: string
+    """
+    try:
+        return json.dumps(value, indent=indent)
+    except (TypeError, ValueError):
+        return value

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -26,7 +26,7 @@ from ckanext.scheming.validation import (
     scheming_multiple_choice_output,
     scheming_isodatetime,
     scheming_isodatetime_tz,
-    scheming_valid_json,
+    scheming_valid_json_object,
     scheming_load_json,
 )
 from ckanext.scheming.logic import (
@@ -110,7 +110,7 @@ class _SchemingMixin(object):
             'convert_to_json_if_datetime': convert_to_json_if_datetime,
             'scheming_isodatetime': scheming_isodatetime,
             'scheming_isodatetime_tz': scheming_isodatetime_tz,
-            'scheming_valid_json': scheming_valid_json,
+            'scheming_valid_json_object': scheming_valid_json_object,
             'scheming_load_json': scheming_load_json,
             }
 

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -25,7 +25,9 @@ from ckanext.scheming.validation import (
     scheming_multiple_choice,
     scheming_multiple_choice_output,
     scheming_isodatetime,
-    scheming_isodatetime_tz
+    scheming_isodatetime_tz,
+    scheming_valid_json,
+    scheming_load_json,
 )
 from ckanext.scheming.logic import (
     scheming_dataset_schema_list,
@@ -92,6 +94,7 @@ class _SchemingMixin(object):
             'scheming_get_timezones': helpers.scheming_get_timezones,
             'scheming_datetime_to_tz': helpers.scheming_datetime_to_tz,
             'scheming_datastore_choices': helpers.scheming_datastore_choices,
+            'scheming_display_json_value': helpers.scheming_display_json_value,
             }
 
     def get_validators(self):
@@ -107,6 +110,8 @@ class _SchemingMixin(object):
             'convert_to_json_if_datetime': convert_to_json_if_datetime,
             'scheming_isodatetime': scheming_isodatetime,
             'scheming_isodatetime_tz': scheming_isodatetime_tz,
+            'scheming_valid_json': scheming_valid_json,
+            'scheming_load_json': scheming_load_json,
             }
 
     def _add_template_directory(self, config):

--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -113,9 +113,9 @@
       }
     },
     {
-      "preset_name": "json",
+      "preset_name": "json_object",
       "values": {
-        "validators": "ignore_missing scheming_valid_json",
+        "validators": "ignore_missing scheming_valid_json_object",
         "output_validators": "scheming_load_json",
         "form_snippet": "json.html",
         "display_snippet": "json.html"

--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -115,7 +115,7 @@
     {
       "preset_name": "json_object",
       "values": {
-        "validators": "ignore_missing scheming_valid_json_object",
+        "validators": "scheming_required scheming_valid_json_object",
         "output_validators": "scheming_load_json",
         "form_snippet": "json.html",
         "display_snippet": "json.html"

--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -111,6 +111,16 @@
         "display_snippet": "datetime_tz.html",
         "validators": "scheming_isodatetime_tz convert_to_json_if_datetime"
       }
+    },
+    {
+      "preset_name": "json",
+      "values": {
+        "validators": "ignore_missing scheming_valid_json",
+        "output_validators": "scheming_load_json",
+        "form_snippet": "json.html",
+        "display_snippet": "json.html"
+      }
     }
+
   ]
 }

--- a/ckanext/scheming/templates/scheming/display_snippets/json.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/json.html
@@ -1,0 +1,1 @@
+{{ h.scheming_display_json_value(data[field.field_name], indent=field.get('indent', 2)) }}

--- a/ckanext/scheming/templates/scheming/form_snippets/json.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/json.html
@@ -1,0 +1,15 @@
+{% import 'macros/form.html' as form %}
+
+{% call form.textarea(
+    field.field_name,
+    id='field-' + field.field_name,
+    label=h.scheming_language_text(field.label),
+    placeholder=h.scheming_language_text(field.form_placeholder),
+    value=h.scheming_display_json_value(data[field.field_name], indent=field.get('indent', 2)),
+    error=errors[field.field_name],
+    attrs=field.form_attrs or {"class": "form-control"},
+    is_required=h.scheming_field_required(field),
+    )
+%}
+    {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+{% endcall %}

--- a/ckanext/scheming/tests/test_dataset_display.py
+++ b/ckanext/scheming/tests/test_dataset_display.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_true
+from nose.tools import assert_true, assert_in
 
 from ckantoolkit.tests.factories import Sysadmin, Dataset
 from ckantoolkit.tests.helpers import FunctionalTestBase, submit_and_follow
@@ -91,3 +91,22 @@ class TestDatasetDisplay(FunctionalTestBase):
                     in response.body)
         assert_true('<ul><li>Often friendly</li></ul>'
                     not in response.body)
+
+    def test_json_field_displayed(self):
+        user = Sysadmin()
+        d = Dataset(
+            user=user,
+            type='test-schema',
+            name='plain-json',
+            a_json_field={'a': '1', 'b': '2'},
+            )
+        app = self._get_test_app()
+        response = app.get(url='/dataset/plain-json')
+
+        expected = '''{
+  "a": "1", 
+  "b": "2"
+}'''.replace('"', '&#34;')   # Ask webhelpers
+
+        assert_in(expected, response.body)
+        assert_in('Example JSON', response.body)

--- a/ckanext/scheming/tests/test_form.py
+++ b/ckanext/scheming/tests/test_form.py
@@ -1,8 +1,14 @@
-from nose import SkipTest
-from nose.tools import assert_true
+import json
 
-from ckantoolkit.tests.factories import Sysadmin
-from ckantoolkit.tests.helpers import FunctionalTestBase, submit_and_follow
+from nose import SkipTest
+from nose.tools import assert_true, assert_in, assert_equals
+
+
+from ckantoolkit.tests.factories import Sysadmin, Dataset
+from ckantoolkit.tests.helpers import (
+    FunctionalTestBase, submit_and_follow, call_action
+)
+
 
 def _get_package_new_page_as_sysadmin(app):
     user = Sysadmin()
@@ -13,6 +19,37 @@ def _get_package_new_page_as_sysadmin(app):
     )
     return env, response
 
+
+def _get_package_update_page_as_sysadmin(app, id):
+    user = Sysadmin()
+    env = {'REMOTE_USER': user['name'].encode('ascii')}
+    response = app.get(
+        url='/test-schema/edit/{}'.format(id),
+        extra_environ=env,
+    )
+    return env, response
+
+
+def _get_resource_new_page_as_sysadmin(app, id):
+    user = Sysadmin()
+    env = {'REMOTE_USER': user['name'].encode('ascii')}
+    response = app.get(
+        url='/dataset/new_resource/{}'.format(id),
+        extra_environ=env,
+    )
+    return env, response
+
+
+def _get_resource_update_page_as_sysadmin(app, id, resource_id):
+    user = Sysadmin()
+    env = {'REMOTE_USER': user['name'].encode('ascii')}
+    response = app.get(
+        url='/dataset/{}/resource_edit/{}'.format(id, resource_id),
+        extra_environ=env,
+    )
+    return env, response
+
+
 def _get_organization_new_page_as_sysadmin(app):
     user = Sysadmin()
     env = {'REMOTE_USER': user['name'].encode('ascii')}
@@ -22,6 +59,7 @@ def _get_organization_new_page_as_sysadmin(app):
     )
     return env, response
 
+
 def _get_group_new_page_as_sysadmin(app):
     user = Sysadmin()
     env = {'REMOTE_USER': user['name'].encode('ascii')}
@@ -30,6 +68,8 @@ def _get_group_new_page_as_sysadmin(app):
         extra_environ=env,
     )
     return env, response
+
+
 
 class TestDatasetFormNew(FunctionalTestBase):
     def test_dataset_form_includes_custom_fields(self):
@@ -77,3 +117,133 @@ class TestGroupFormNew(FunctionalTestBase):
         # Failing until https://github.com/ckan/ckan/pull/2617 is merged
         # assert_true('bookface' in form.fields)
         raise SkipTest
+
+
+class TestJSONDatasetForm(FunctionalTestBase):
+
+    def test_dataset_form_includes_json_fields(self):
+        app = self._get_test_app()
+        env, response = _get_package_new_page_as_sysadmin(app)
+        form = response.forms['dataset-edit']
+        assert_in('a_json_field', form.fields)
+        assert_equals(form.fields['a_json_field'][0].tag, 'textarea')
+
+    def test_dataset_form_create(self):
+        app = self._get_test_app()
+        env, response = _get_package_new_page_as_sysadmin(app)
+        form = response.forms['dataset-edit']
+
+        value = {
+            'a': 1,
+            'b': 2,
+        }
+        json_value = json.dumps(value)
+
+        form['name'] = 'json_dataset_1'
+        form['a_json_field'] = json_value
+
+        submit_and_follow(app, form, env, 'save')
+
+        dataset = call_action('package_show', id='json_dataset_1')
+
+        assert_equals(dataset['a_json_field'], value)
+
+    def test_dataset_form_update(self):
+        value = {
+            'a': 1,
+            'b': 2,
+        }
+        dataset = Dataset(
+            type='test-schema',
+            a_json_field=value)
+
+        app = self._get_test_app()
+        env, response = _get_package_update_page_as_sysadmin(
+            app, dataset['id'])
+        form = response.forms['dataset-edit']
+
+        assert_equals(form['a_json_field'].value, json.dumps(value, indent=2))
+
+        value = {
+            'a': 1,
+            'b': 2,
+            'c': 3,
+        }
+        json_value = json.dumps(value)
+
+        form['a_json_field'] = json_value
+
+        submit_and_follow(app, form, env, 'save')
+
+        dataset = call_action('package_show', id=dataset['id'])
+
+        assert_equals(dataset['a_json_field'], value)
+
+
+class TestJSONResourceForm(FunctionalTestBase):
+
+    def test_resource_form_includes_json_fields(self):
+        dataset = Dataset(type='test-schema')
+
+        app = self._get_test_app()
+        env, response = _get_resource_new_page_as_sysadmin(app, dataset['id'])
+        form = response.forms['resource-edit']
+        assert_in('a_resource_json_field', form.fields)
+        assert_equals(form.fields['a_resource_json_field'][0].tag, 'textarea')
+
+    def test_resource_form_create(self):
+        dataset = Dataset(type='test-schema')
+
+        app = self._get_test_app()
+        env, response = _get_resource_new_page_as_sysadmin(app, dataset['id'])
+        form = response.forms['resource-edit']
+
+        value = {
+            'a': 1,
+            'b': 2,
+        }
+        json_value = json.dumps(value)
+
+        form['url'] = 'http://example.com/data.csv'
+        form['a_resource_json_field'] = json_value
+
+        submit_and_follow(app, form, env, 'save')
+
+        dataset = call_action('package_show', id=dataset['id'])
+
+        assert_equals(dataset['resources'][0]['a_resource_json_field'], value)
+
+    def test_resource_form_update(self):
+        value = {
+            'a': 1,
+            'b': 2,
+        }
+        dataset = Dataset(
+            type='test-schema',
+            resources=[{
+                'url': 'http://example.com/data.csv',
+                'a_resource_json_field': value
+            }]
+        )
+
+        app = self._get_test_app()
+        env, response = _get_resource_update_page_as_sysadmin(
+            app, dataset['id'], dataset['resources'][0]['id'])
+        form = response.forms['resource-edit']
+
+        assert_equals(form['a_resource_json_field'].value, json.dumps(value, indent=2))
+
+        value = {
+            'a': 1,
+            'b': 2,
+            'c': 3,
+        }
+        json_value = json.dumps(value)
+
+        form['a_resource_json_field'] = json_value
+
+        submit_and_follow(app, form, env, 'save')
+
+        dataset = call_action('package_show', id=dataset['id'])
+
+        assert_equals(dataset['resources'][0]['a_resource_json_field'], value)

--- a/ckanext/scheming/tests/test_form_snippets.py
+++ b/ckanext/scheming/tests/test_form_snippets.py
@@ -4,6 +4,7 @@ from jinja2 import Markup
 
 from ckanext.scheming.tests.mock_pylons_request import mock_pylons_request
 
+
 def render_form_snippet(name, data=None, extra_args=None, **kwargs):
     field = {
         'field_name': 'test',
@@ -17,6 +18,7 @@ def render_form_snippet(name, data=None, extra_args=None, **kwargs):
             data=data or {},
             errors=None,
             **(extra_args or {}))
+
 
 class TestSelectFormSnippet(object):
     def test_choices_visible(self):
@@ -171,3 +173,29 @@ class TestLicenseFormSnippet(object):
             form_include_blank_choice=True,
             extra_args={'licenses': [('Aaa', 'aa'), ('Bbb', 'bb')]})
         assert_in('<option value=""></option>', html)
+
+
+class TestJSONFormSnippet(object):
+    def test_json_value(self):
+        html = render_form_snippet(
+            'json.html',
+            field_name='a_json_field',
+            data={'a_json_field': {'a': '1', 'b': '2'}},
+        )
+        expected = '''{
+  "a": "1", 
+  "b": "2"
+}'''.replace('"', '&#34;')   # Ask webhelpers
+
+        assert_in(expected, html)
+
+    def test_json_value_no_indent(self):
+        html = render_form_snippet(
+            'json.html',
+            field_name='a_json_field',
+            data={'a_json_field': {'a': '1', 'b': '2'}},
+            indent=None
+        )
+        expected = '''{"a": "1", "b": "2"}'''.replace('"', '&#34;')
+
+        assert_in(expected, html)

--- a/ckanext/scheming/tests/test_helpers.py
+++ b/ckanext/scheming/tests/test_helpers.py
@@ -77,7 +77,7 @@ class TestGetPreset(object):
             u'datetime_tz',
             u'dataset_slug',
             u'dataset_organization',
-            u'json',
+            u'json_object',
         )), sorted(presets.iterkeys()))
 
     def test_scheming_get_preset(self):

--- a/ckanext/scheming/tests/test_helpers.py
+++ b/ckanext/scheming/tests/test_helpers.py
@@ -76,7 +76,8 @@ class TestGetPreset(object):
             u'datetime',
             u'datetime_tz',
             u'dataset_slug',
-            u'dataset_organization'
+            u'dataset_organization',
+            u'json',
         )), sorted(presets.iterkeys()))
 
     def test_scheming_get_preset(self):

--- a/ckanext/scheming/tests/test_schema.json
+++ b/ckanext/scheming/tests/test_schema.json
@@ -82,7 +82,7 @@
     {
       "label": "Example JSON",
       "field_name": "a_json_field",
-      "preset": "json"
+      "preset": "json_object"
     }
   ],
   "resource_fields": [
@@ -124,7 +124,7 @@
     {
       "label": "Example JSON Resource",
       "field_name": "a_resource_json_field",
-      "preset": "json"
+      "preset": "json_object"
     }
   ]
 }

--- a/ckanext/scheming/tests/test_schema.json
+++ b/ckanext/scheming/tests/test_schema.json
@@ -78,6 +78,11 @@
       "field_name": "other",
       "label": {"en": "Other information"},
       "output_validators": "ignore_missing"
+    },
+    {
+      "label": "Example JSON",
+      "field_name": "a_json_field",
+      "preset": "json"
     }
   ],
   "resource_fields": [
@@ -115,7 +120,11 @@
       "label": "Date Taken",
       "label_time": "Time Taken",
       "preset": "datetime_tz"
+    },
+    {
+      "label": "Example JSON Resource",
+      "field_name": "a_resource_json_field",
+      "preset": "json"
     }
-
   ]
 }

--- a/ckanext/scheming/tests/test_validation.py
+++ b/ckanext/scheming/tests/test_validation.py
@@ -4,6 +4,7 @@ import pytz
 from nose.tools import assert_raises, assert_equals
 from ckanapi import LocalCKAN, ValidationError
 
+from ckan.tests.helpers import reset_db
 from ckanext.scheming.errors import SchemingException
 from ckanext.scheming.validation import get_validator_or_converter, scheming_required
 from ckanext.scheming.plugins import (
@@ -51,6 +52,8 @@ class TestChoices(object):
             category='f2hybrid',
             )
         assert_equals(d['category'], 'f2hybrid')
+
+        reset_db()
 
 class TestRequired(object):
     def test_required_is_set_to_true(self):
@@ -534,3 +537,291 @@ class TestInvalidType(object):
         p = SchemingGroupsPlugin.instance
         data, errors = p.validate({}, {'type': 'banana'}, {}, 'dataset_show')
         assert_equals(list(errors), ['type'])
+
+
+class TestJSONValidatorsDatasetValid(object):
+
+    def teardown(self):
+        reset_db()
+
+    def test_valid_json_string_object(self):
+        lc = LocalCKAN()
+        dataset = lc.action.package_create(
+            type='test-schema',
+            name='bob_json_1',
+            a_json_field='{"a": 1, "b": 2}',
+        )
+
+        assert_equals(dataset['a_json_field'], {'a': 1, 'b': 2})
+
+    def test_valid_json_string_list(self):
+        lc = LocalCKAN()
+        dataset = lc.action.package_create(
+            type='test-schema',
+            name='bob_json_1',
+            a_json_field='[{"a": 1}, {"b": 2}]',
+        )
+        assert_equals(dataset['a_json_field'], [{'a': 1}, {'b': 2}])
+
+    def test_valid_json_object(self):
+        lc = LocalCKAN()
+        dataset = lc.action.package_create(
+            type='test-schema',
+            name='bob_json_1',
+            a_json_field={'a': 1, 'b': 2},
+        )
+
+        assert_equals(dataset['a_json_field'], {'a': 1, 'b': 2})
+
+
+class TestJSONValidatorsResourceValid(object):
+
+    def teardown(self):
+        reset_db()
+
+    def test_valid_json_string_object(self):
+        lc = LocalCKAN()
+        dataset = lc.action.package_create(
+            type='test-schema',
+            name='bob_json_1',
+            resources=[{
+                'url': 'http://example.com/data.csv',
+                'a_resource_json_field': '{"a": 1, "b": 2}'
+            }],
+        )
+
+        assert_equals(
+                dataset['resources'][0]['a_resource_json_field'],
+                {'a': 1, 'b': 2})
+
+    def test_valid_json_string_list(self):
+        lc = LocalCKAN()
+        dataset = lc.action.package_create(
+            type='test-schema',
+            name='bob_json_1',
+            resources=[{
+                'url': 'http://example.com/data.csv',
+                'a_resource_json_field': '[{"a": 1}, {"b": 2}]'
+            }],
+        )
+
+        assert_equals(
+                dataset['resources'][0]['a_resource_json_field'],
+                [{'a': 1}, {'b': 2}])
+
+    def test_valid_json_object(self):
+        lc = LocalCKAN()
+        dataset = lc.action.package_create(
+            type='test-schema',
+            name='bob_json_1',
+            resources=[{
+                'url': 'http://example.com/data.csv',
+                'a_resource_json_field': {'a': 1, 'b': 2}
+            }],
+        )
+
+        assert_equals(
+                dataset['resources'][0]['a_resource_json_field'],
+                {'a': 1, 'b': 2})
+
+
+class TestJSONValidatorsDatasetInvalid(object):
+
+    def test_invalid_json_string_not_json(self):
+        lc = LocalCKAN()
+        try:
+            lc.action.package_create(
+                type='test-schema',
+                name='bob_json_1',
+                a_json_field='not-json',
+            )
+        except ValidationError as e:
+            assert e.error_dict['a_json_field'][0].startswith(
+                'Invalid JSON string: No JSON object could be decoded')
+        else:
+            raise AssertionError('ValidationError not raised')
+
+    def test_invalid_json_string_values(self):
+        lc = LocalCKAN()
+        values = [
+            '22',
+            'true',
+            'false',
+            'null',
+        ]
+        for value in values:
+            try:
+                lc.action.package_create(
+                    type='test-schema',
+                    name='bob_json_1',
+                    a_json_field=value,
+                )
+            except ValidationError as e:
+                assert e.error_dict['a_json_field'][0].startswith(
+                    'Unsupported value for JSON field')
+            else:
+                raise AssertionError('ValidationError not raised')
+
+    def test_invalid_json_string(self):
+        lc = LocalCKAN()
+        try:
+            lc.action.package_create(
+                type='test-schema',
+                name='bob_json_1',
+                a_json_field='{"type": "walnut", "codes": 1, 2 ,3}',
+            )
+        except ValidationError as e:
+            assert e.error_dict['a_json_field'][0].startswith(
+                'Invalid JSON string: Expecting property name')
+        else:
+            raise AssertionError('ValidationError not raised')
+
+    def test_invalid_json_object(self):
+        lc = LocalCKAN()
+        try:
+            lc.action.package_create(
+                type='test-schema',
+                name='bob_json_1',
+                a_json_field={
+                    'type': 'walnut',
+                    'date': datetime.datetime.utcnow()
+                },
+            )
+        except ValidationError as e:
+            assert e.error_dict['a_json_field'][0].startswith(
+                'Invalid JSON object:')
+            assert e.error_dict['a_json_field'][0].endswith(
+                'is not JSON serializable')
+        else:
+            raise AssertionError('ValidationError not raised')
+
+    def test_invalid_json_value(self):
+        lc = LocalCKAN()
+
+        values = [
+            True,
+            datetime.datetime.utcnow(),
+            (2, 3),
+            23,
+            [1, 2, 3],
+        ]
+        for value in values:
+            try:
+                lc.action.package_create(
+                    type='test-schema',
+                    name='bob_json_1',
+                    a_json_field=value,
+                )
+            except ValidationError as e:
+                assert e.error_dict['a_json_field'][0].startswith(
+                    'Unsupported type for JSON field:')
+            else:
+                raise AssertionError('ValidationError not raised')
+
+
+class TestJSONValidatorsResourceInvalid(object):
+
+    def test_invalid_json_string_not_json(self):
+        lc = LocalCKAN()
+        try:
+            lc.action.package_create(
+                type='test-schema',
+                name='bob_json_1',
+                resources=[{
+                    'url': 'http://example.com/data.csv',
+                    'a_resource_json_field': 'not-json',
+                }],
+            )
+        except ValidationError as e:
+            assert e.error_dict['resources'][0]['a_resource_json_field'][0].startswith(
+                'Invalid JSON string: No JSON object could be decoded')
+        else:
+            raise AssertionError('ValidationError not raised')
+
+    def test_invalid_json_string_values(self):
+        lc = LocalCKAN()
+        values = [
+            '22',
+            'true',
+            'false',
+            'null',
+        ]
+        for value in values:
+            try:
+                lc.action.package_create(
+                    type='test-schema',
+                    name='bob_json_1',
+                    resources=[{
+                        'url': 'http://example.com/data.csv',
+                        'a_resource_json_field': value
+                    }],
+                )
+            except ValidationError as e:
+                assert e.error_dict['resources'][0]['a_resource_json_field'][0].startswith(
+                    'Unsupported value for JSON field')
+            else:
+                raise AssertionError('ValidationError not raised')
+
+    def test_invalid_json_string(self):
+        lc = LocalCKAN()
+        try:
+            lc.action.package_create(
+                type='test-schema',
+                name='bob_json_1',
+                resources=[{
+                    'url': 'http://example.com/data.csv',
+                    'a_resource_json_field': '{"type": "walnut", "codes": 1, 2 ,3}'
+                }],
+            )
+        except ValidationError as e:
+            assert e.error_dict['resources'][0]['a_resource_json_field'][0].startswith(
+                'Invalid JSON string: Expecting property name')
+        else:
+            raise AssertionError('ValidationError not raised')
+
+    def test_invalid_json_object(self):
+        lc = LocalCKAN()
+        try:
+            lc.action.package_create(
+                type='test-schema',
+                name='bob_json_1',
+                resources=[{
+                    'url': 'http://example.com/data.csv',
+                    'a_resource_json_field': {
+                        'type': 'walnut',
+                        'date': datetime.datetime.utcnow()
+                    }
+                }],
+            )
+        except ValidationError as e:
+            assert e.error_dict['resources'][0]['a_resource_json_field'][0].startswith(
+                'Invalid JSON object:')
+            assert e.error_dict['resources'][0]['a_resource_json_field'][0].endswith(
+                'is not JSON serializable')
+        else:
+            raise AssertionError('ValidationError not raised')
+
+    def test_invalid_json_value(self):
+        lc = LocalCKAN()
+
+        values = [
+            True,
+            datetime.datetime.utcnow(),
+            (2, 3),
+            23
+        ]
+        for value in values:
+            try:
+                lc.action.package_create(
+                    type='test-schema',
+                    name='bob_json_1',
+                    resources=[{
+                        'url': 'http://example.com/data.csv',
+                        'a_resource_json_field': value
+                    }],
+                )
+            except ValidationError as e:
+                assert e.error_dict['resources'][0]['a_resource_json_field'][0].startswith(
+                    'Unsupported type for JSON field:')
+            else:
+                raise AssertionError('ValidationError not raised')

--- a/ckanext/scheming/tests/test_validation.py
+++ b/ckanext/scheming/tests/test_validation.py
@@ -4,7 +4,7 @@ import pytz
 from nose.tools import assert_raises, assert_equals
 from ckanapi import LocalCKAN, ValidationError
 
-from ckan.tests.helpers import reset_db
+from ckan.tests.helpers import FunctionalTestBase
 from ckanext.scheming.errors import SchemingException
 from ckanext.scheming.validation import get_validator_or_converter, scheming_required
 from ckanext.scheming.plugins import (
@@ -26,7 +26,7 @@ class TestGetValidatorOrConverter(object):
         assert get_validator_or_converter('remove_whitespace')
 
 
-class TestChoices(object):
+class TestChoices(FunctionalTestBase):
     def test_choice_field_only_accepts_given_choices(self):
         lc = LocalCKAN()
 
@@ -53,7 +53,6 @@ class TestChoices(object):
             )
         assert_equals(d['category'], 'f2hybrid')
 
-        reset_db()
 
 class TestRequired(object):
     def test_required_is_set_to_true(self):
@@ -539,10 +538,7 @@ class TestInvalidType(object):
         assert_equals(list(errors), ['type'])
 
 
-class TestJSONValidatorsDatasetValid(object):
-
-    def teardown(self):
-        reset_db()
+class TestJSONValidatorsDatasetValid(FunctionalTestBase):
 
     def test_valid_json_string_object(self):
         lc = LocalCKAN()
@@ -574,10 +570,7 @@ class TestJSONValidatorsDatasetValid(object):
         assert_equals(dataset['a_json_field'], {'a': 1, 'b': 2})
 
 
-class TestJSONValidatorsResourceValid(object):
-
-    def teardown(self):
-        reset_db()
+class TestJSONValidatorsResourceValid(FunctionalTestBase):
 
     def test_valid_json_string_object(self):
         lc = LocalCKAN()

--- a/ckanext/scheming/tests/test_validation.py
+++ b/ckanext/scheming/tests/test_validation.py
@@ -550,15 +550,6 @@ class TestJSONValidatorsDatasetValid(FunctionalTestBase):
 
         assert_equals(dataset['a_json_field'], {'a': 1, 'b': 2})
 
-    def test_valid_json_string_list(self):
-        lc = LocalCKAN()
-        dataset = lc.action.package_create(
-            type='test-schema',
-            name='bob_json_1',
-            a_json_field='[{"a": 1}, {"b": 2}]',
-        )
-        assert_equals(dataset['a_json_field'], [{'a': 1}, {'b': 2}])
-
     def test_valid_json_object(self):
         lc = LocalCKAN()
         dataset = lc.action.package_create(
@@ -586,21 +577,6 @@ class TestJSONValidatorsResourceValid(FunctionalTestBase):
         assert_equals(
                 dataset['resources'][0]['a_resource_json_field'],
                 {'a': 1, 'b': 2})
-
-    def test_valid_json_string_list(self):
-        lc = LocalCKAN()
-        dataset = lc.action.package_create(
-            type='test-schema',
-            name='bob_json_1',
-            resources=[{
-                'url': 'http://example.com/data.csv',
-                'a_resource_json_field': '[{"a": 1}, {"b": 2}]'
-            }],
-        )
-
-        assert_equals(
-                dataset['resources'][0]['a_resource_json_field'],
-                [{'a': 1}, {'b': 2}])
 
     def test_valid_json_object(self):
         lc = LocalCKAN()
@@ -641,6 +617,7 @@ class TestJSONValidatorsDatasetInvalid(object):
             'true',
             'false',
             'null',
+            '[1,2,3]',
         ]
         for value in values:
             try:
@@ -738,6 +715,7 @@ class TestJSONValidatorsResourceInvalid(object):
             'true',
             'false',
             'null',
+            '[1,2,3]',
         ]
         for value in values:
             try:
@@ -801,6 +779,7 @@ class TestJSONValidatorsResourceInvalid(object):
             True,
             datetime.datetime.utcnow(),
             (2, 3),
+            [2, 3],
             23
         ]
         for value in values:

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -226,6 +226,51 @@ def scheming_isodatetime_tz(field, schema):
     return validator
 
 
+def scheming_valid_json(value, context):
+    """Store a JSON object as a serialized JSON string
+
+    It accepts two types of inputs:
+        1. A valid serialized JSON string (it must be an object or a list)
+        2. An object that can be serialized to JSON
+
+    """
+    if not value:
+        return
+    elif isinstance(value, basestring):
+        try:
+            loaded = json.loads(value)
+
+            if not isinstance(loaded, (dict, list)):
+                raise Invalid(
+                    _('Unsupported value for JSON field: {}'.format(value))
+                )
+
+            return value
+        except (ValueError, TypeError) as e:
+            raise Invalid(_('Invalid JSON string: {}'.format(e)))
+
+    elif isinstance(value, dict):
+        try:
+            return json.dumps(value)
+        except (ValueError, TypeError) as e:
+            raise Invalid(_('Invalid JSON object: {}'.format(e)))
+    else:
+        raise Invalid(
+            _('Unsupported type for JSON field: {}'.format(type(value)))
+        )
+
+    return value
+
+
+def scheming_load_json(value, context):
+    if isinstance(value, basestring):
+        try:
+            return json.loads(value)
+        except ValueError:
+            return value
+    return value
+
+
 def scheming_multiple_choice_output(value):
     """
     return stored json as a proper list

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -242,21 +242,21 @@ def scheming_valid_json_object(value, context):
 
             if not isinstance(loaded, dict):
                 raise Invalid(
-                    _('Unsupported value for JSON field: {}'.format(value))
+                    _('Unsupported value for JSON field: {}').format(value)
                 )
 
             return value
         except (ValueError, TypeError) as e:
-            raise Invalid(_('Invalid JSON string: {}'.format(e)))
+            raise Invalid(_('Invalid JSON string: {}').format(e))
 
     elif isinstance(value, dict):
         try:
             return json.dumps(value)
         except (ValueError, TypeError) as e:
-            raise Invalid(_('Invalid JSON object: {}'.format(e)))
+            raise Invalid(_('Invalid JSON object: {}').format(e))
     else:
         raise Invalid(
-            _('Unsupported type for JSON field: {}'.format(type(value)))
+            _('Unsupported type for JSON field: {}').format(type(value))
         )
 
     return value

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -226,7 +226,7 @@ def scheming_isodatetime_tz(field, schema):
     return validator
 
 
-def scheming_valid_json(value, context):
+def scheming_valid_json_object(value, context):
     """Store a JSON object as a serialized JSON string
 
     It accepts two types of inputs:
@@ -240,7 +240,7 @@ def scheming_valid_json(value, context):
         try:
             loaded = json.loads(value)
 
-            if not isinstance(loaded, (dict, list)):
+            if not isinstance(loaded, dict):
                 raise Invalid(
                     _('Unsupported value for JSON field: {}'.format(value))
                 )


### PR DESCRIPTION
This preset allows to input JSON strings, and load these into the dataset object, eg when passing it to a template or via the API.

The JSON fields accepts JSON strings that serialize objects or lists (and nothing else), but also dicts that can be dumped as JSON. eg

```python

call_action('package_create',
            name='test-json',
            'a_json_field'='{"a": 1, "b": 2}')

call_action('package_create',
            name='test-json',
            'a_json_field'={'a': 1, 'b': 2})

```

both create the following dataset:

```json
{
    "name": "test-json",
    "a_json_field": {
        "a": 1,
        "b": 2
    }
}

```

Lists are not allowed directly due to limitations on CKAN validation code.

The JSON fields can also be used in resources.

Tests cover validation, form and display snippets and also some functional tests, both for dataset and resource fields.