### PR TITLE
Update resource url validator to match CKAN core

### DIFF
--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -41,7 +41,7 @@
     {
       "preset_name": "resource_url_upload",
       "values": {
-        "validators": "not_empty unicode remove_whitespace",
+        "validators": "ignore_missing unicode remove_whitespace",
         "form_snippet": "upload.html",
         "form_placeholder": "http://example.com/my-data.csv",
         "upload_field": "upload",


### PR DESCRIPTION
Resource URL has been optional for a while

@wardi if someone is using this preset it might change their logic, but at the same time I think it's good to keep presets in sync with core. Perhaps we should release a new scheming version? or is it not worth it?