### PR TITLE
 Do not dump empty strings in JSON field

### DIFF
--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -339,8 +339,6 @@ def scheming_display_json_value(value, indent=2):
         serialized.
     :rtype: string
     """
-    if not value:
-        return value
     try:
         return json.dumps(value, indent=indent, sort_keys=True)
     except (TypeError, ValueError):

--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -338,6 +338,8 @@ def scheming_display_json_value(value, indent=2):
         serialized.
     :rtype: string
     """
+    if not value:
+        return value
     try:
         return json.dumps(value, indent=indent, sort_keys=True)
     except (TypeError, ValueError):

--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -339,6 +339,8 @@ def scheming_display_json_value(value, indent=2):
         serialized.
     :rtype: string
     """
+    if isinstance(value, basestring):
+        return value
     try:
         return json.dumps(value, indent=indent, sort_keys=True)
     except (TypeError, ValueError):

--- a/ckanext/scheming/templates/scheming/display_snippets/json.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/json.html
@@ -1,1 +1,1 @@
-{{ h.scheming_display_json_value(data[field.field_name], indent=field.get('indent', 2)) }}
+{% if data[field.field_name] %}{{  h.scheming_display_json_value(data[field.field_name], indent=field.get('indent', 2)) }}{% endif %}

--- a/ckanext/scheming/templates/scheming/form_snippets/json.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/json.html
@@ -1,11 +1,11 @@
 {% import 'macros/form.html' as form %}
-
+{% set value = data[field.field_name] %}
 {% call form.textarea(
     field.field_name,
     id='field-' + field.field_name,
     label=h.scheming_language_text(field.label),
     placeholder=h.scheming_language_text(field.form_placeholder),
-    value=h.scheming_display_json_value(data[field.field_name], indent=field.get('indent', 2)),
+    value=h.scheming_display_json_value(value, indent=field.get('indent', 2)) if value else None,
     error=errors[field.field_name],
     attrs=field.form_attrs or {"class": "form-control"},
     is_required=h.scheming_field_required(field),

--- a/ckanext/scheming/tests/test_form_snippets.py
+++ b/ckanext/scheming/tests/test_form_snippets.py
@@ -209,3 +209,14 @@ class TestJSONFormSnippet(object):
         expected = '></textarea>'
 
         assert_in(expected, html)
+
+    def test_json_value_is_displayed_correctly_if_string(self):
+        value = '{"a": 1, "b": 2}'
+        html = render_form_snippet(
+            'json.html',
+            field_name='a_json_field',
+            data={'a_json_field': value},
+        )
+        expected = value.replace('"', '&#34;')
+
+        assert_in(expected, html)

--- a/ckanext/scheming/tests/test_form_snippets.py
+++ b/ckanext/scheming/tests/test_form_snippets.py
@@ -199,3 +199,13 @@ class TestJSONFormSnippet(object):
         expected = '''{"a": "1", "b": "2"}'''.replace('"', '&#34;')
 
         assert_in(expected, html)
+
+    def test_json_value_is_empty_with_no_value(self):
+        html = render_form_snippet(
+            'json.html',
+            field_name='a_json_field',
+            data={'a_json_field': ''},
+        )
+        expected = '></textarea>'
+
+        assert_in(expected, html)

--- a/ckanext/scheming/tests/test_helpers.py
+++ b/ckanext/scheming/tests/test_helpers.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
+import datetime
+
 from nose.tools import assert_equals
 from mock import patch, Mock
 
@@ -9,6 +11,7 @@ from ckanext.scheming.helpers import (
     scheming_get_preset,
     scheming_get_presets,
     scheming_datastore_choices,
+    scheming_display_json_value,
 )
 
 from ckanapi import NotFound, NotAuthorized
@@ -154,3 +157,47 @@ class TestDatastoreChoices(object):
             resource_id='all-params',
             limit=5,
             fields=['a', 'b'])
+
+
+class TestJSONHelpers(object):
+
+    def test_display_json_value_default(self):
+
+        value = {'a': 'b'}
+
+        assert_equals(scheming_display_json_value(value), '{\n  "a": "b"\n}')
+
+    def test_display_json_value_indent(self):
+
+        value = {'a': 'b'}
+
+        assert_equals(
+            scheming_display_json_value(value, indent=4), '{\n    "a": "b"\n}')
+
+    def test_display_json_value_no_indent(self):
+
+        value = {'a': 'b'}
+
+        assert_equals(
+            scheming_display_json_value(value, indent=None), '{"a": "b"}')
+
+    def test_display_json_value_keys_are_sorted(self):
+
+        value = {'c': 'd', 'a': 'b'}
+
+        assert_equals(
+                scheming_display_json_value(value, indent=4),
+                '{\n    "a": "b", \n    "c": "d"\n}')
+
+    def test_display_json_value_json_error(self):
+
+        date = datetime.datetime.now()
+        value = ('a', date)
+
+        assert_equals(scheming_display_json_value(value), ('a', date))
+
+    def test_display_json_value_empty_string(self):
+
+        value = ''
+
+        assert_equals(scheming_display_json_value(value, indent=None), '')

--- a/ckanext/scheming/tests/test_helpers.py
+++ b/ckanext/scheming/tests/test_helpers.py
@@ -195,9 +195,3 @@ class TestJSONHelpers(object):
         value = ('a', date)
 
         assert_equals(scheming_display_json_value(value), ('a', date))
-
-    def test_display_json_value_empty_string(self):
-
-        value = ''
-
-        assert_equals(scheming_display_json_value(value, indent=None), '')


### PR DESCRIPTION
When passed an empty string (`''`), the helper used to display the fields with JSON objects returned a pair of quotes (`'""'`) because that's what `json.dumps` does. This is what happens when the field is
empty or there is an error in the form and the data is returned.

Added a few tests as well.