### PR TITLE
Remove check to avoid adding template dir more than once

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -115,9 +115,6 @@ class _SchemingMixin(object):
             }
 
     def _add_template_directory(self, config):
-        if _SchemingMixin._template_dir_added:
-            return
-        _SchemingMixin._template_dir_added = True
         add_template_directory(config, 'templates')
 
     def _load_presets(self, config):


### PR DESCRIPTION
This check prevents the extension from working on CKAN<=2.5. Because of the way plugins/templates are loaded in these versions, the function is called multiple times in different contexts, so after the first pass, the templates folder is not added again eventhough it hasn't been added to the `config` object. See eg:

https://travis-ci.org/frictionlessdata/ckanext-validation/builds/293081805
https://travis-ci.org/frictionlessdata/ckanext-validation/jobs/293081809

We could check the exact key in config with the value to make sure it needs adding but `add_template_folder()` already checks for duplicates so it seems easier to just call it every time.