### PR TITLE
Skip rendering fields in form if form_snippet is false

### DIFF
--- a/ckanext/scheming/templates/scheming/snippets/form_field.html
+++ b/ckanext/scheming/templates/scheming/snippets/form_field.html
@@ -3,13 +3,18 @@
 
 {%- set form_snippet = field.form_snippet -%}
 
-{%- if not form_snippet -%}
-  {%- set form_snippet = 'text.html' -%}
-{%- endif -%}
+{#- If explicitly marked as false in the schema, skip the field completely -#}
+{%- if not form_snippet is sameas false -%}
 
-{%- if '/' not in form_snippet -%}
-  {%- set form_snippet = 'scheming/form_snippets/' + form_snippet -%}
-{%- endif -%}
+  {%- if not form_snippet -%}
+    {%- set form_snippet = 'text.html' -%}
+  {%- endif -%}
 
-{%- snippet form_snippet, field=field, data=data, errors=errors,
-  licenses=licenses, entity_type=entity_type, object_type=object_type -%}
+  {%- if '/' not in form_snippet -%}
+    {%- set form_snippet = 'scheming/form_snippets/' + form_snippet -%}
+  {%- endif -%}
+
+  {%- snippet form_snippet, field=field, data=data, errors=errors,
+    licenses=licenses, entity_type=entity_type, object_type=object_type -%}
+
+{%- endif -%}


### PR DESCRIPTION
Allow fields to not be displayed in the form if you want to deal with them internally or manually add them to another snippet.

I used `false` instead of `null` to keep the current behaviour of using the text snippet if `form_snippet` was not defined.