### PR TITLE
Show email address if the email name field is empty

### DIFF
--- a/ckanext/scheming/templates/scheming/display_snippets/email.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/email.html
@@ -1,3 +1,3 @@
 {{ h.mail_to(email_address=data[field.field_name],
-   name=data[field.display_email_name_field] if field.display_email_name_field
+   name=data[field.display_email_name_field] if field.display_email_name_field and data[field.display_email_name_field]
    else data[field.field_name]) }}


### PR DESCRIPTION
If the name field is optional and the user has not filled it, the display snippet does not display anything.