### PR TITLE
Get the group type from the data_dict in setup_template_variables

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -162,6 +162,7 @@ class _GroupOrganizationMixin(object):
         return list(self._schemas)
 
     def setup_template_variables(self, context, data_dict, group_type=None):
+        group_type = data_dict.get('type')
         if not group_type:
             if c.group_dict:
                 group_type = c.group_dict['type']

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -161,7 +161,7 @@ class _GroupOrganizationMixin(object):
     def group_types(self):
         return list(self._schemas)
 
-    def setup_template_variables(self, context, data_dict, group_type=None):
+    def setup_template_variables(self, context, data_dict):
         group_type = data_dict.get('type')
         if not group_type:
             if c.group_dict:


### PR DESCRIPTION
This is connected to ckan/ckan#4032, specifically to https://github.com/ckan/ckan/pull/4032/commits/e8f26b461c5e11bc36d2c233093f0c9f0d5cb801

The scheming function expects a `group_type` keyword, but that's not what the core interface is passing. Rather we check for type in the `data_dict`, otherwise when rendering the new organization form for a cusotm type you get an exception because it tries to look for a schema with the key
"organization":

```
File '/srv/app/src/ckan/ckan/controllers/group.py', line 475 in new
  self._setup_template_variables(context, data, group_type=group_type)
File '/srv/app/src/ckan/ckan/controllers/group.py', line 59 in _setup_template_variables
  setup_template_variables(context, data_dict)
File '/srv/app/src_extensions/ckanext-scheming/ckanext/scheming/plugins.py', line 170 in setup_template_variables
  c.scheming_schema = self._schemas[group_type]
KeyError: 'organization'
```