### PR TITLE
Don't render delete button on create form

### DIFF
--- a/.circleci-matrix.yml
+++ b/.circleci-matrix.yml
@@ -3,7 +3,6 @@ env:
 - CKAN_VERSION=release-v2.4-latest
 - CKAN_VERSION=release-v2.5-latest
 - CKAN_VERSION=dev-v2.6
-- CKAN_VERSION=dev-v2.7
 
 command:
 - cd ckan; git reset --hard; git checkout $CKAN_VERSION

--- a/.circleci-matrix.yml
+++ b/.circleci-matrix.yml
@@ -2,8 +2,8 @@ env:
 #- CKAN_VERSION=release-v2.3-latest    XXX: disable one until clean db works
 - CKAN_VERSION=release-v2.4-latest
 - CKAN_VERSION=release-v2.5-latest
-- CKAN_VERSION=release-v2.6-latest
 - CKAN_VERSION=dev-v2.6
+- CKAN_VERSION=dev-v2.7
 
 command:
 - cd ckan; git reset --hard; git checkout $CKAN_VERSION

--- a/ckanext/scheming/custom_group_with_status.json
+++ b/ckanext/scheming/custom_group_with_status.json
@@ -1,0 +1,48 @@
+{
+  "scheming_version": 1,
+  "group_type": "theme",
+  "about_url": "http://github.com/ckan/ckanext-scheming",
+  "fields": [
+    {
+      "field_name": "title",
+      "label": "Name",
+      "validators": "ignore_missing unicode",
+      "form_snippet": "large_text.html",
+      "form_attrs": {"data-module": "slug-preview-target"},
+      "form_placeholder": "My theme"
+    },
+    {
+      "field_name": "name",
+      "label": "URL",
+      "validators": "not_empty unicode name_validator group_name_validator",
+      "form_snippet": "slug.html",
+      "form_placeholder": "my-theme"
+    },
+    {
+      "field_name": "notes",
+      "label": "Description",
+      "form_snippet": "markdown.html",
+      "form_placeholder": "A little information about my group..."
+    },
+    {
+      "field_name": "url",
+      "label": "Image URL",
+      "form_placeholder": "http://example.com/my-image.jpg"
+    },
+    {
+      "field_name": "status",
+      "label": "Status",
+      "output_validators": "ignore_missing",
+      "choices": [
+        {
+            "label": "In Progress",
+            "value": "in-progress"
+        },
+        {
+            "label": "Final",
+            "value": "final"
+        }
+      ]
+    }
+  ]
+}

--- a/ckanext/scheming/custom_org_with_address.json
+++ b/ckanext/scheming/custom_org_with_address.json
@@ -1,0 +1,38 @@
+{
+  "scheming_version": 1,
+  "organization_type": "publisher",
+  "about_url": "http://github.com/ckan/ckanext-scheming",
+  "fields": [
+    {
+      "field_name": "title",
+      "label": "Name",
+      "validators": "ignore_missing unicode",
+      "form_snippet": "large_text.html",
+      "form_attrs": {"data-module": "slug-preview-target"},
+      "form_placeholder": "My theme"
+    },
+    {
+      "field_name": "name",
+      "label": "URL",
+      "validators": "not_empty unicode name_validator group_name_validator",
+      "form_snippet": "slug.html",
+      "form_placeholder": "my-theme"
+    },
+    {
+      "field_name": "notes",
+      "label": "Description",
+      "form_snippet": "markdown.html",
+      "form_placeholder": "A little information about my group..."
+    },
+    {
+      "field_name": "url",
+      "label": "Image URL",
+      "form_placeholder": "http://example.com/my-image.jpg"
+    },
+    {
+      "field_name": "address",
+      "label": "Address",
+      "output_validators": "ignore_missing"
+    }
+  ]
+}

--- a/ckanext/scheming/templates/scheming/group/group_form.html
+++ b/ckanext/scheming/templates/scheming/group/group_form.html
@@ -15,9 +15,11 @@
 
     <div class="form-actions">
         {% block delete_button %}
-        {% if h.check_access('group_delete', {'id': data.id}) and action=='edit'  %}
-        {% set locale = h.dump_json({'content': _('Are you sure you want to delete this Group?')}) %}
-        <a class="btn btn-danger pull-left" href="{% url_for controller='group', action='delete', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+        {% if action == 'edit' %}
+          {% if h.check_access('group_delete', {'id': data.id}) and action=='edit'  %}
+            {% set locale = h.dump_json({'content': _('Are you sure you want to delete this Group?')}) %}
+            <a class="btn btn-danger pull-left" href="{% url_for controller='group', action='delete', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+          {% endif %}
         {% endif %}
         {% endblock %}
         <button class="btn btn-primary" name="save" type="submit">{% block save_text %}{{ _('Save Group') }}{% endblock %}</button>

--- a/ckanext/scheming/templates/scheming/organization/group_form.html
+++ b/ckanext/scheming/templates/scheming/organization/group_form.html
@@ -15,9 +15,11 @@
 
     <div class="form-actions">
         {% block delete_button %}
-        {% if h.check_access('group_delete', {'id': data.id}) and action=='edit'  %}
-        {% set locale = h.dump_json({'content': _('Are you sure you want to delete this Organization?')}) %}
-        <a class="btn btn-danger pull-left" href="{% url_for controller='organization', action='delete', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+        {% if action == 'edit' %}
+          {% if h.check_access('group_delete', {'id': data.id}) and action=='edit'  %}
+            {% set locale = h.dump_json({'content': _('Are you sure you want to delete this Organization?')}) %}
+            <a class="btn btn-danger pull-left" href="{% url_for controller='organization', action='delete', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+          {% endif %}
         {% endif %}
         {% endblock %}
         <button class="btn btn-primary" name="save" type="submit">{% block save_text %}{{ _('Save Organization') }}{% endblock %}</button>

--- a/ckanext/scheming/tests/test_form.py
+++ b/ckanext/scheming/tests/test_form.py
@@ -1,4 +1,5 @@
 import json
+import ckantoolkit
 
 from nose import SkipTest
 from nose.tools import assert_true, assert_in, assert_equals
@@ -114,6 +115,10 @@ class TestOrganizationFormNew(FunctionalTestBase):
 
 class TestGroupFormNew(FunctionalTestBase):
     def test_group_form_includes_custom_field(self):
+
+        if not ckantoolkit.check_ckan_version(min_version='2.7.0'):
+            raise SkipTest
+
         app = self._get_test_app()
         env, response = _get_group_new_page_as_sysadmin(app)
         form = response.forms[1]  # FIXME: add an id to this form
@@ -130,6 +135,10 @@ class TestGroupFormNew(FunctionalTestBase):
 
 class TestCustomGroupFormNew(FunctionalTestBase):
     def test_group_form_includes_custom_field(self):
+
+        if not ckantoolkit.check_ckan_version(min_version='2.8.0'):
+            raise SkipTest
+
         app = self._get_test_app()
         env, response = _get_group_new_page_as_sysadmin(app, type='theme')
         form = response.forms[1]
@@ -142,7 +151,12 @@ class TestCustomGroupFormNew(FunctionalTestBase):
 
 
 class TestCustomOrgFormNew(FunctionalTestBase):
+
     def test_org_form_includes_custom_field(self):
+
+        if not ckantoolkit.check_ckan_version(min_version='2.8.0'):
+            raise SkipTest
+
         app = self._get_test_app()
         env, response = _get_organization_new_page_as_sysadmin(
             app, type='publisher')

--- a/ckanext/scheming/tests/test_group_logic.py
+++ b/ckanext/scheming/tests/test_group_logic.py
@@ -5,7 +5,7 @@ class TestGroupSchemaLists(object):
     def test_group_schema_list(self):
         lc = LocalCKAN('visitor')
         group_schemas = lc.action.scheming_group_schema_list()
-        assert_equals(group_schemas, ['group'])
+        assert_equals(sorted(group_schemas), ['group', 'theme'])
 
     def test_group_schema_show(self):
         lc = LocalCKAN('visitor')
@@ -22,7 +22,7 @@ class TestGroupSchemaLists(object):
     def test_organization_schema_list(self):
         lc = LocalCKAN('visitor')
         org_schemas = lc.action.scheming_organization_schema_list()
-        assert_equals(org_schemas, ['organization'])
+        assert_equals(sorted(org_schemas), ['organization', 'publisher'])
 
     def test_organization_schema_show(self):
         lc = LocalCKAN('visitor')

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../ckan/test-core.ini
+use = config:../../src/ckan/test-core.ini
 
 ckan.plugins = scheming_datasets scheming_groups scheming_organizations
                scheming_test_plugin
@@ -17,7 +17,9 @@ scheming.dataset_schemas = ckanext.scheming:ckan_dataset.json
                            ckanext.scheming.tests:test_schema.json
                            ckanext.scheming.tests:test_datastore_choices.json
 scheming.organization_schemas = ckanext.scheming:org_with_dept_id.json
+                                ckanext.scheming:custom_org_with_address.json
 scheming.group_schemas = ckanext.scheming:group_with_bookface.json
+                         ckanext.scheming:custom_group_with_status.json
 
 ckan.site_logo = /img/logo_64px_wide.png
 ckan.favicon = /images/icons/ckan.ico

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../../src/ckan/test-core.ini
+use = config:../ckan/test-core.ini
 
 ckan.plugins = scheming_datasets scheming_groups scheming_organizations
                scheming_test_plugin


### PR DESCRIPTION
Not sure what jinja magic was at play before but this block should only be rendered if `data.id` is present (ie it's an edit). This has surfaced since we starting passing the group_type in the data_dict in ckan/ckan#4032, and is now causing an exception when rendering the new org/group form.

