### PR TITLE
Hide resource fields

### DIFF
--- a/ckanext/scheming/templates/scheming/package/snippets/resource_form.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/resource_form.html
@@ -18,9 +18,11 @@
   {%- endif -%}
   {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
   {%- for field in schema.resource_fields -%}
-    {%- snippet 'scheming/snippets/form_field.html',
-      field=field, data=data, errors=errors,
-      entity_type='dataset', object_type=dataset_type -%}
+    {%- if field.form_snippet is not none -%}
+      {%- snippet 'scheming/snippets/form_field.html',
+        field=field, data=data, errors=errors,
+	entity_type='dataset', object_type=dataset_type -%}
+    {%- endif -%}
   {%- endfor -%}
 {% endblock %}
 


### PR DESCRIPTION
Analogous to _package_form.html_, enable a resource field to be hidden in _resource_form.html_ if `"form_snippet": null` for that field in the schema.