### PR TITLE
Use common i18n functions instead of Pylons one

### DIFF
--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -3,8 +3,7 @@ import datetime
 import pytz
 import json
 
-from pylons import config
-from pylons.i18n import gettext
+from ckantoolkit import config, _
 
 from ckanapi import LocalCKAN, NotFound, NotAuthorized
 
@@ -49,9 +48,9 @@ def scheming_language_text(text, prefer_lang=None):
         l, v = sorted(text.items())[0]
         return v
 
-    t = gettext(text)
-    if isinstance(t, str):
-        return t.decode('utf-8')
+    if isinstance(text, str):
+        text = text.decode('utf-8')
+    t = _(text)
     return t
 
 
@@ -119,7 +118,7 @@ def scheming_datastore_choices(field):
         fields = [f['id'] for f in result['fields'] if f['id'] != '_id']
 
     return [{'value': r[fields[0]], 'label': r[fields[1]]}
-        for r in result['records']]
+            for r in result['records']]
 
 
 def scheming_field_required(field):
@@ -316,7 +315,7 @@ def scheming_datetime_to_tz(date, tz):
 
 def scheming_get_timezones(field):
     def to_options(list):
-        return [{'value':tz, 'text':tz} for tz in list]
+        return [{'value': tz, 'text': tz} for tz in list]
 
     def validate_tz(list):
         return [tz for tz in list if tz in pytz.all_timezones]

--- a/ckanext/scheming/tests/test_helpers.py
+++ b/ckanext/scheming/tests/test_helpers.py
@@ -11,13 +11,13 @@ from ckanext.scheming.helpers import (
     scheming_datastore_choices,
 )
 
-from ckanapi import NotFound, NotAuthorized
+from ckanapi import NotFound
 
 
 class TestLanguageText(object):
-    @patch('ckanext.scheming.helpers.gettext')
-    def test_pass_through_gettext(self, gettext):
-        gettext.side_effect = lambda x: x + '1'
+    @patch('ckanext.scheming.helpers._')
+    def test_pass_through_gettext(self, _):
+        _.side_effect = lambda x: x + '1'
         assert_equals('hello1', scheming_language_text('hello'))
 
     def test_only_one_language(self):


### PR DESCRIPTION
Dataset requests are served by Flask now, so we can't use the Pylons functions (which is bad anyway). Core's underscore function calls ugettext under the hood, so we moved the unicode check before calling
it.