### PR TITLE
Preliminary support for validators in dict WIP

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -30,6 +30,7 @@ from ckanext.scheming import loader
 from ckanext.scheming.errors import SchemingException
 from ckanext.scheming.validation import (
     validators_from_string,
+    validators_from_dict,
     scheming_choices,
     scheming_required,
     scheming_multiple_choice,
@@ -413,8 +414,11 @@ def _field_output_validators(f, schema, convert_extras,
     else:
         validators = [ignore_missing]
     if 'output_validators' in f:
-        validators += validators_from_string(
-            f['output_validators'], f, schema)
+        if isinstance(f['output_validators'], dict):
+            validators = validators_from_dict(f['output_validators'], f, schema)
+        else:
+            validators += validators_from_string(
+                f['output_validators'], f, schema)
     return validators
 
 
@@ -424,7 +428,10 @@ def _field_validators(f, schema, convert_extras):
     """
     validators = []
     if 'validators' in f:
-        validators = validators_from_string(f['validators'], f, schema)
+        if isinstance(f['validators'], dict):
+            validators = validators_from_dict(f['validators'], f, schema)
+        else:
+            validators = validators_from_string(f['validators'], f, schema)
     elif helpers.scheming_field_required(f):
         validators = [not_empty, unicode]
     else:

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -305,6 +305,19 @@ def validators_from_string(s, field, schema):
     return out
 
 
+def validators_from_dict(d, field, schema):
+
+    out = {}
+    for key, value in d.iteritems():
+        out[key] = []
+        parts = value.split()
+        for p in parts:
+            v = get_validator_or_converter(p)
+            out[key].append(v)
+
+    return out
+
+
 def get_validator_or_converter(name):
     """
     Get a validator or converter by name


### PR DESCRIPTION
Fixes #75 

This PR enables to have dict of validators instead of just list of string.

For example

```
    {
      "field_name": "groups",
      "label": "Categories",
      "preset": "multiple_checkbox",
      "validators": {
        "id": "ignore_missing unicode_safe",
        "name": "ignore_missing unicode_safe",
        "title": "ignore_missing unicode_safe",
        "__extras": "ignore"
      },
      "output_validators": {
        "id": "ignore_missing",
        "name": "ignore_missing",
        "title": "ignore_missing"
      }
    }
```

If the schema defines groups (which is a core field) in any kind of definition, posting groups with the dataset eg. using package_create in the api will fail with validation error of having things in __junk.

This is work in progress as it probably has some things not yet considered and missing tests, but i wanted to put it out for discussion anyway.