### PR TITLE
Fix passing field_name into form.input_block

### DIFF
--- a/ckanext/scheming/templates/scheming/form_snippets/multiple_select.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/multiple_select.html
@@ -5,7 +5,7 @@
 {% endmacro %}
 
 {%- call form.input_block(
-    "field-{{ field.field_name }}",
+    "field-" + field.field_name,
     label=h.scheming_language_text(field.label),
     classes=['control-full'],
     error=errors[field.field_name],


### PR DESCRIPTION
It was not being parsed when inside quotes so was passed literally