### PR TITLE
Fix select_size setting

### DIFF
--- a/ckanext/scheming/templates/scheming/form_snippets/multiple_select.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/multiple_select.html
@@ -21,7 +21,7 @@
     {%- set choices = choices|sort(case_sensitive=false, attribute=1) -%}
   {%- endif -%}
   <select multiple
-      size="{{ ([field.get('select_size', 10), field.choices|length]|sort)[0] }}"
+      size="{{ field.get('select_size', field.choices|length) }}"
       style="display: block"
       id="field-{{ field.field_name }}"
       name="{{ field.field_name }}"


### PR DESCRIPTION
Using the sort was a neat trick but didn't work because it sorted as a string not a number so the user's select_size setting was being ignored