### PR TITLE
tags needs its own form_snippet to fix css class

### DIFF
--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -24,6 +24,7 @@
       "preset_name": "tag_string_autocomplete",
       "values": {
         "validators": "ignore_missing tag_string_convert",
+        "form_snippet": "tags.html",
         "classes": ["control-full"],
         "form_attrs": {
           "data-module": "autocomplete",

--- a/ckanext/scheming/templates/scheming/form_snippets/tags.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/tags.html
@@ -1,0 +1,16 @@
+{% import 'macros/form.html' as form %}
+
+{% call form.input(
+    field.field_name,
+    id='field-' + field.field_name,
+    label=h.scheming_language_text(field.label),
+    placeholder=h.scheming_language_text(field.form_placeholder),
+    value=data[field.field_name],
+    error=errors[field.field_name],
+    classes=field.classes if 'classes' in field else ['control-medium'],
+    attrs=dict({"class": "NOT-form-control"}, **(field.get('form_attrs', {}))),
+    is_required=h.scheming_field_required(field)
+    )
+%}
+    {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+{% endcall %}


### PR DESCRIPTION
CSS includes form-control which causes incorrect layout.
In order to remove form-control we need a new form_snippet for tags; same as for text but without form-control.
Fixes https://github.com/ckan/ckanext-scheming/issues/219
except only for tags not file format or other glitches.