### PR TITLE
Retain extra metadata fields

### DIFF
--- a/ckanext/scheming/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/package_form.html
@@ -31,4 +31,10 @@
 {% endblock %}
 
 {% block metadata_fields %}
+  {% block package_metadata_fields_custom %}
+    {% block custom_fields %}
+      {% snippet 'snippets/custom_form_fields.html', extras=data.extras, errors=errors, limit=3 %}
+    {% endblock %}
+  {% endblock %}
 {% endblock %}
+


### PR DESCRIPTION
Allow users creating datasets to enter additional metadata, as per the default when scheming is not used. 

Fixes

https://github.com/ckan/ckanext-scheming/issues/14
