### PR TITLE
Improvement: Add support for organization image file uploads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ This extension includes the following presets:
 * `"dataset_organization"` - organization validation and form select box
 * `"resource_url_upload"` - resource url validaton and link/upload form
   field
+  * `"organization_url_upload"` - organization url validaton and link/upload form
+  field
 * `"resource_format_autocomplete"` - resource format validation with
   format guessing based on url and autocompleting form field
 * `"json_object"` - JSON based input. Only JSON objects are supported.
@@ -264,6 +266,8 @@ This extension includes the following form snippets:
   an organization selection field for datasets
 * [upload.html](ckanext/scheming/templates/scheming/form_snippets/upload.html) -
   an upload field for resource files
+  * [organization_upload.html](ckanext/scheming/templates/scheming/form_snippets/organization_upload.html) -
+  an upload field for organization logo files
 * [select.html](ckanext/scheming/templates/scheming/form_snippets/select.html) -
   a select box
 * [multiple_checkbox.html](ckanext/scheming/templates/scheming/form_snippets/multiple_choice.html) -

--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -51,6 +51,14 @@
       }
     },
     {
+      "preset_name": "organization_url_upload",
+      "values": {
+        "validators": "ignore_missing unicode remove_whitespace",
+        "form_snippet": "organization_upload.html",
+        "form_placeholder": "http://example.com/my-data.csv"
+      }
+    },
+    {
       "preset_name": "resource_format_autocomplete",
       "values": {
         "validators": "if_empty_guess_format ignore_missing clean_format unicode",

--- a/ckanext/scheming/templates/scheming/form_snippets/organization_upload.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/organization_upload.html
@@ -1,0 +1,16 @@
+{% import 'macros/form.html' as form %}
+
+{% set is_upload = data.image_url and not data.image_url.startswith('http') %}
+{% set is_url = data.image_url and data.image_url.startswith('http') %}
+
+{{ form.image_upload(
+    data,
+    errors,
+    is_upload_enabled=h.uploads_enabled(),
+    is_url=is_url,
+    is_upload=is_upload
+    ) 
+}}
+
+{# image_upload macro doesn't support call #}
+{%- snippet 'scheming/form_snippets/help_text.html', field=field -%}

--- a/ckanext/scheming/tests/test_helpers.py
+++ b/ckanext/scheming/tests/test_helpers.py
@@ -69,6 +69,7 @@ class TestGetPreset(object):
             u'tag_string_autocomplete',
             u'select',
             u'resource_url_upload',
+            u'organization_url_upload',
             u'resource_format_autocomplete',
             u'multiple_select',
             u'multiple_checkbox',


### PR DESCRIPTION
This PR creates a new form template and preset to handle Organization logo file uploads. 

After reviewing core CKAN templates I noticed some differences in some variables and calling of the `form.image_upload` macro between resources and organization uploads.

**Current Behaviour:**
Using the existing `upload.html` template and related preset does not properly upload organization logos. The file name is not put through the validators, and the frontend is not able to locate the file on the server ( e.g. `<img src="http://127.0.0.1/uploads/group/Screenshot from 2019-12-23 08-51-59.png" width="200" alt="adsffffdsfddsf">`). However, there does not seem to be any errors thrown. The form submits successfully and the image display name is saved as the file name (before validation).

**Expected Behaviour:**
User should be able to upload an image to an organization, have it's validators run, and be visible on the frontend.