### PR TITLE
Restore licenses in v2.9

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -9,6 +9,7 @@ from functools import wraps
 import six
 
 import ckan.plugins as p
+import ckan.model as model
 from ckan.common import c
 try:
     from ckan.lib.helpers import helper_functions as core_helper_functions
@@ -294,6 +295,15 @@ class SchemingDatasetsPlugin(p.SingletonPlugin, DefaultDatasetForm,
             'scheming_dataset_schema_list': scheming_dataset_schema_list,
             'scheming_dataset_schema_show': scheming_dataset_schema_show,
         }
+
+    def setup_template_variables(self, context, data_dict):
+        super(SchemingDatasetsPlugin, self).setup_template_variables(
+            context, data_dict)
+        # do not override licenses if they were already added by some
+        # other extension. We just want to make sure, that licenses
+        # are not empty.
+        if not hasattr(c, 'licenses'):
+            c.licenses = [('', '')] + model.Package.get_license_options()
 
 
 class SchemingGroupsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,

--- a/ckanext/scheming/tests/test_form.py
+++ b/ckanext/scheming/tests/test_form.py
@@ -86,6 +86,18 @@ class TestDatasetFormNew(object):
         form = BeautifulSoup(response.body).select_one("#resource-edit")
         assert form.select("input[name=camels_in_photo]")
 
+    @pytest.mark.ckan_config("scheming.dataset_schemas", "ckanext.scheming:ckan_dataset.json")
+    def test_dataset_form_includes_licenses(self, app, sysadmin_env):
+        """Starting from CKAN v2.9, licenses are not available as template
+        variable and we are extendisn
+        `DefaultDatasetForm::setup_template_variables` in order to change
+        it.
+        """
+        response = app.get(url="/dataset/new", extra_environ=sysadmin_env)
+        page = BeautifulSoup(response.body)
+        licenses = page.select('#field-license_id option')
+        assert licenses
+
 
 @pytest.mark.usefixtures("clean_db")
 class TestOrganizationFormNew(object):


### PR DESCRIPTION
In CKAN 2.9 license options for the dataset form are generated [in template](https://github.com/ckan/ckan/blob/master/ckan/templates/package/snippets/package_basic_fields.html#L36) and there is no `c.licenses`. Helper function in v2.9 generate slightly different result from what we have in previous versions, so it would be safer to reproduce old behavior and add `c.licenses` via `setup_template_variables`. Personally, I'd like to use logic from the master, but it will break existing overrides to `license.html` . So, it can't be helped and we must add `license` into `c` object.