### PR TITLE
wip: Add validator for null form_snippets to prevent removing values.

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -40,6 +40,7 @@ from ckanext.scheming.validation import (
     scheming_isodatetime_tz,
     scheming_valid_json_object,
     scheming_load_json,
+    scheming_do_not_change_if_missing,
 )
 from ckanext.scheming.logic import (
     scheming_dataset_schema_list,
@@ -140,6 +141,7 @@ class _SchemingMixin(object):
             'scheming_isodatetime_tz': scheming_isodatetime_tz,
             'scheming_valid_json_object': scheming_valid_json_object,
             'scheming_load_json': scheming_load_json,
+            'scheming_do_not_change_if_missing': scheming_do_not_change_if_missing,
             }
 
     @run_once_for_caller('_scheming_add_template_directory', lambda: None)

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -229,6 +229,32 @@ def scheming_isodatetime_tz(field, schema):
     return validator
 
 
+@scheming_validator
+def scheming_do_not_change_if_missing(field, schema):
+    """
+    Do not change a value if key is missing.
+    Default behavior during package_update is to remove value.
+    """
+    def validator(key, data, errors, context):
+        package = context.get('package')
+        if package:
+            original = package.extras.get(key[0], '')
+        value = data.get(key[0], '')
+
+        # May require separate validator for read_only fields
+        # that are set programatically elsewhere. In which case
+        # there may not be a need to compare values, just revert
+        # to original always, not just when empty.
+        # if original != value:
+        #    data[key] = original
+
+        if not value:
+            # silently replace with the old value when none is sent
+            data[key] = original
+
+    return validator
+
+
 def scheming_valid_json_object(value, context):
     """Store a JSON object as a serialized JSON string
 


### PR DESCRIPTION
When using ckanext-scheming you are able to add a field to your schema but have it hidden in the web form UI by using `"form_snippet": null`.  However, when a user edits the package the value/key are removed from the package object.

This validator allows you to hide the `form_snippet` without losing the value of the field.  This does not create a read only version as in this use-case, the desire is to just not lose the existing value for "hidden" form fields. A read only value may require its own validator to prevent editing if a value is provided.  This validator allows editing of the value via an API call for instance.

I've suggested this for scheming as the hidden form aspect that it's tied to is here instead CKAN core.

This was more or less lifted from ckanext-canada.

Related PRs / Issues:
PR #168 
Issue #66 
https://github.com/ckan/ckan/issues/1839#issuecomment-48755345