### PR TITLE
Restore auto-generation of resource name

### DIFF
--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -47,7 +47,8 @@
         "form_placeholder": "http://example.com/my-data.csv",
         "upload_field": "upload",
         "upload_clear": "clear_upload",
-        "upload_label": "File"
+        "upload_label": "File",
+        "upload_name": "name"
       }
     },
     {

--- a/ckanext/scheming/templates/scheming/form_snippets/upload.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/upload.html
@@ -12,7 +12,8 @@
     is_upload=is_upload,
     upload_label=h.scheming_language_text(field.upload_label),
     url_label=h.scheming_language_text(field.label),
-    placeholder=field.form_placeholder
+    placeholder=field.form_placeholder,
+    field_name=field.upload_name
     )
 }}
 {# image_upload macro doesn't support call #}


### PR DESCRIPTION
I think, starting from the latest patch-releases, the resource name won't be generated using the name of the uploaded file. 

There was [name attribute](https://github.com/ckan/ckan/blob/2.7/ckan/templates/package/snippets/resource_form.html#L24) added to [image_upload macro](https://github.com/ckan/ckan/blob/2.7/ckan/templates/macros/form.html#L409). The value of this attribute is used for selecting input(by the `name` HTML attr) which will be filled with the auto-generated name. The current version of presets doesn't have such value and default version from macro(`image_url`) won't work, because, in case of resource form, name of the field is `name`