### PR TITLE
Block to extend display of repeating subfields

### DIFF
--- a/ckanext/scheming/templates/scheming/snippets/display_field.html
+++ b/ckanext/scheming/templates/scheming/snippets/display_field.html
@@ -3,6 +3,7 @@
 {%- if field.repeating_subfields %}
   {% set fields = data[field.field_name] %}
 
+{% block subfield_display %}
   {% for field_data in fields %}
     <div class="panel panel-default">
       <header class="panel-heading">
@@ -27,6 +28,7 @@
       </div>
     </div>
   {% endfor %}
+{% endblock %}
 {% else %}
   {%- set display_snippet = field.display_snippet -%}
 


### PR DESCRIPTION
Adds a block surrounding repeating sub-field panels to allow override of display.