### PR TITLE
#219 fix Tag appearance

### DIFF
--- a/ckanext/scheming/assets/styles/scheming.css
+++ b/ckanext/scheming/assets/styles/scheming.css
@@ -34,7 +34,7 @@ a.btn.btn-multiple-remove {
 
 /* Fix Tag fields:
  https://github.com/ckan/ckanext-scheming/issues/219 */
-.select2-container.select2-container-multi.form-control{
-  height:auto;
+.select2-container.select2-container-multi.form-control {
+  height: auto;
   padding: unset;
 }

--- a/ckanext/scheming/assets/styles/scheming.css
+++ b/ckanext/scheming/assets/styles/scheming.css
@@ -32,17 +32,9 @@ a.btn.btn-multiple-remove {
 }
 
 
-/* Harmonize form fields heigh for multiple_text fields */
-.control-full input, .control-full select, .control-full textarea {
-  height: 34px;
-}
-
-/* Fix Tag fields https://github.com/ckan/ckanext-scheming/issues/219 */
-.select2-container{
+/* Fix Tag fields:
+ https://github.com/ckan/ckanext-scheming/issues/219 */
+.select2-container.select2-container-multi.form-control{
   height:auto;
-}
-
-/* reduce the select2-container double form effect */
-.form-control {
   padding: unset;
 }

--- a/ckanext/scheming/assets/styles/scheming.css
+++ b/ckanext/scheming/assets/styles/scheming.css
@@ -31,3 +31,18 @@ a.btn.btn-multiple-remove {
   border-radius: 100px;
 }
 
+
+/* Harmonize form fields heigh for multiple_text fields */
+.control-full input, .control-full select, .control-full textarea {
+  height: 34px;
+}
+
+/* Fix Tag fields https://github.com/ckan/ckanext-scheming/issues/219 */
+.select2-container{
+  height:auto;
+}
+
+/* reduce the select2-container double form effect */
+.form-control {
+  padding: unset;
+}


### PR DESCRIPTION
This should address:
https://github.com/ckan/ckanext-scheming/issues/219

Since Select2 comes from the core, I'm wondering if we would like to port the .select2-container class fix to the core instead of patching it here...

Note that I'm intentionally not abusing !important usage, it's not necessary