### PR TITLE
Add div around help text to fix formatting

### DIFF
--- a/ckanext/scheming/templates/scheming/form_snippets/upload.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/upload.html
@@ -16,4 +16,6 @@
     )
 }}
 {# image_upload macro doesn't support call #}
-{%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+<div class="form-group">
+  {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+</div>


### PR DESCRIPTION
Without inheriting from the form-group class, the help_text text is not
formatted properly, so add a div around it to fix.