### PR TITLE
Add allow_html option for help_text

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,10 @@ Only if this key is supplied, its value will be shown as inline help text,
 Help text must be plain text, no markdown or HTML are allowed.
 Help text may be provided in multiple languages like [label fields](#label).
 
+#### `help_allow_html`
+
+Allow HTML inside the help text if set to `true`. Default is `false`.
+
 #### `help_inline`
 
 Display help text inline if set to `true`. Default is `false`.

--- a/ckanext/scheming/templates/scheming/form_snippets/help_text.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/help_text.html
@@ -1,8 +1,9 @@
 {% import 'macros/form.html' as form %}
 
 {%- if field.help_text -%}
+    {% set text = h.scheming_language_text(field.help_text) %}
     {{- form.info(
-        text=h.scheming_language_text(field.help_text),
+        text=text|safe if field.get('help_allow_html', false) else text,
         inline=field.get('help_inline', false)
         ) -}}
 {%- endif -%}


### PR DESCRIPTION
Sometimes we want to add some links into the help text.
This PR adds an option to allow html inside the help_text.