### PR TITLE
fix tags field broken layout by deleting redundant class

### DIFF
--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -28,7 +28,8 @@
         "form_attrs": {
           "data-module": "autocomplete",
           "data-module-tags": "",
-          "data-module-source": "/api/2/util/tag/autocomplete?incomplete=?"
+          "data-module-source": "/api/2/util/tag/autocomplete?incomplete=?",
+          "class": ""
         }
       }
     },


### PR DESCRIPTION
Tags field inherits the form-control class from text.html form_snippet and it breaks the layout a bit. As a solution we can clear the class attribute to avoid this issue.