### PR TITLE
Do not install py2 test dependencies inside py3

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,9 @@
 factory-boy>=2
 mock
-soupsieve==1.2  # python2 compat beautifulsoup dep
-importlib-metadata==1.6.1  # python2 compat beautifulsoup dep
-configparser==3.8.1  # python2 compat beautifulsoup dep
-zipp==1.2.0  # python2 compat beautifulsoup dep
+soupsieve==1.2; python_version < "3.0"  # python2 compat beautifulsoup dep
+importlib-metadata==1.6.1; python_version < "3.0"  # python2 compat beautifulsoup dep
+configparser==3.8.1; python_version < "3.0"  # python2 compat beautifulsoup dep
+zipp==1.2.0; python_version < "3.0"  # python2 compat beautifulsoup dep
 beautifulsoup4==4.8.2
 pytest==4.6.5
 pytest-ckan


### PR DESCRIPTION
It's not critical, but these libraries can break a lot of pytest plugins. For example, pytest-randomly(I'm using it), which runs tests in random order.
Anyway, there is no reason to install these dependencies inside py3 environment

PS these libraries will be installed in py3 as a dependency of beautiful soup, without version restrictions