### PR TITLE
Add form_attrs to repeating fields

### DIFF
--- a/ckanext/scheming/templates/scheming/form_snippets/repeating_subfields.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/repeating_subfields.html
@@ -50,39 +50,40 @@
   h.scheming_language_text(field.label) or field.field_name,
   [],
   field.classes if 'classes' in field else ['control-medium'],
-  dict({"class": "form-control"}, **(field.get('form_attrs', {}))),
   is_required=h.scheming_field_required(field)) %}
-  <fieldset name="scheming-repeating-subfields" class="scheming-fieldset" data-module="scheming-repeating-subfields">
-    {% set alert_warning = h.scheming_language_text(field.form_alert_warning) %}
-    {% if alert_warning %}
-      <section class="alert alert-warning">
-        {{ alert_warning|safe }}
-      </section>
-    {% endif %}
+    <div {{ form.attributes(dict({"class": "form-control"}, **(field.get('form_attrs', {})))) }}>
+      <fieldset name="scheming-repeating-subfields" class="scheming-fieldset" data-module="scheming-repeating-subfields">
+	{% set alert_warning = h.scheming_language_text(field.form_alert_warning) %}
+	{% if alert_warning %}
+	  <section class="alert alert-warning">
+	    {{ alert_warning|safe }}
+	  </section>
+	{% endif %}
 
-    {%- set group_data = data[field.field_name] -%}
-    {%- set group_count = group_data|length -%}
-    {%- if not group_count and 'id' not in data -%}
-      {%- set group_count = field.form_blanks|default(1) -%}
-    {%- endif -%}
+	{%- set group_data = data[field.field_name] -%}
+	{%- set group_count = group_data|length -%}
+	{%- if not group_count and 'id' not in data -%}
+	  {%- set group_count = field.form_blanks|default(1) -%}
+	{%- endif -%}
 
-    <div class="scheming-repeating-subfields-group">
-      {% for index in range(group_count) %}
-        {{ repeating_panel(index, index + 1) }}
-      {% endfor %}
+	<div class="scheming-repeating-subfields-group">
+	  {% for index in range(group_count) %}
+	    {{ repeating_panel(index, index + 1) }}
+	  {% endfor %}
+	</div>
+	<div class="control-medium">
+	  <a href="javascript:;" name="repeating-add" class="btn btn-link"
+	    >{% block add_button_text %}<i class="fa fa-plus" aria-hidden="true"></i> {{ _('Add') }}{% endblock %}</a>
+
+	  {% set help_text = h.scheming_language_text(field.help_text) %}
+	  {% if help_text %}
+	    <div class="info-block mrgn-tp-md">
+	      {{ help_text }}
+	    </div>
+	  {% endif %}
+	</div>
+
+	<div name="repeating-template" style="display:none">{{ repeating_panel('REPEATING-INDEX0', 'REPEATING-INDEX1') }}</div>
+      </fieldset>
     </div>
-    <div class="control-medium">
-      <a href="javascript:;" name="repeating-add" class="btn btn-link"
-        >{% block add_button_text %}<i class="fa fa-plus" aria-hidden="true"></i> {{ _('Add') }}{% endblock %}</a>
-
-      {% set help_text = h.scheming_language_text(field.help_text) %}
-      {% if help_text %}
-        <div class="info-block mrgn-tp-md">
-          {{ help_text }}
-        </div>
-      {% endif %}
-    </div>
-
-    <div name="repeating-template" style="display:none">{{ repeating_panel('REPEATING-INDEX0', 'REPEATING-INDEX1') }}</div>
-  </fieldset>
 {% endcall %}

--- a/ckanext/scheming/templates/scheming/form_snippets/repeating_subfields.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/repeating_subfields.html
@@ -51,7 +51,7 @@
   [],
   field.classes if 'classes' in field else ['control-medium'],
   is_required=h.scheming_field_required(field)) %}
-    <div {{ form.attributes(dict({"class": "form-control"}, **(field.get('form_attrs', {})))) }}>
+    <div {{ form.attributes(field.get('form_attrs', {})) }}>
       <fieldset name="scheming-repeating-subfields" class="scheming-fieldset" data-module="scheming-repeating-subfields">
 	{% set alert_warning = h.scheming_language_text(field.form_alert_warning) %}
 	{% if alert_warning %}

--- a/ckanext/scheming/tests/test_form_snippets.py
+++ b/ckanext/scheming/tests/test_form_snippets.py
@@ -1,5 +1,6 @@
 import six
 import pytest
+import bs4
 from ckan.lib.base import render_snippet
 from jinja2 import Markup
 
@@ -14,7 +15,7 @@ else:
     from ckanext.scheming.tests.mock_pylons_request import mock_pylons_request
 
 
-def render_form_snippet(name, data=None, extra_args=None, **kwargs):
+def render_form_snippet(name, data=None, extra_args=None, errors=None, **kwargs):
     field = {"field_name": "test", "label": "Test"}
     field.update(kwargs)
     with mock_pylons_request():
@@ -22,7 +23,7 @@ def render_form_snippet(name, data=None, extra_args=None, **kwargs):
             "scheming/form_snippets/" + name,
             field=field,
             data=data or {},
-            errors=None,
+            errors=errors or {},
             **(extra_args or {})
         )
 
@@ -263,3 +264,17 @@ class TestJSONFormSnippet(object):
         expected = value.replace('"', "&#34;")
 
         assert expected in html
+
+
+@pytest.mark.usefixtures("with_request_context")
+class TestRepeatingSubfieldsFormSnippet(object):
+    def test_form_attrs_on_fieldset(self):
+        html = render_form_snippet(
+            "repeating_subfields.html",
+            field_name="repeating",
+            repeating_subfields=[{"field_name": "x"}],
+            form_attrs={"data-module": "test-attrs"},
+        )
+        snippet = bs4.BeautifulSoup(html)
+        attr_holder = snippet.select_one(".controls").div
+        assert attr_holder['data-module'] == 'test-attrs'


### PR DESCRIPTION
At the moment `repeating_fields.html` [makes an attempt to set form_attrs via macro.input_block](https://github.com/ckan/ckanext-scheming/blob/master/ckanext/scheming/templates/scheming/form_snippets/repeating_subfields.html#L53). This macro [doesn't have such option](https://github.com/ckan/ckan/blob/master/ckan/templates/macros/form.html#L285)  and instead of the expected result, all the keys in `form_attrs` appended as extra classes to the rendered block :)

Instead, wrap subfields-fieldset into an extra `div` that contains specified form attributes. 