### PR TITLE
Allow data-modules inside repeating subfields

### DIFF
--- a/ckanext/scheming/assets/js/scheming-repeating-subfields.js
+++ b/ckanext/scheming/assets/js/scheming-repeating-subfields.js
@@ -1,29 +1,51 @@
-this.ckan.module('scheming-repeating-subfields', function($, _) {
+ckan.module('scheming-repeating-subfields', function($) {
   return {
     initialize: function() {
-      var container = this;
-      var $this = $(this.el);
-      var $template = $this.children('div[name="repeating-template"]');
-      var template = $template.html();
-      var $add = $this.find('a[name="repeating-add"]');
+      $.proxyAll(this, /_on/);
+
+      var $template = this.el.children('div[name="repeating-template"]');
+      this.template = $template.html();
       $template.remove();
 
-      $add.on('click', function(e) {
-        var $last = $this.find('.scheming-subfield-group').last();
+      this.el.find('a[name="repeating-add"]').on("click", this._onCreateGroup);
+      this.el.on('click', 'a[name="repeating-remove"]', this._onRemoveGroup);
+    },
+
+    /**
+     * Add new group to the fieldset.
+     *
+     * Fields inside every new group must be renamed in order to form correct
+     * structure during validation:
+     *
+     *  ...
+     *  (parent, INDEX-1, child-1),
+     *  (parent, INDEX-1, child-2),
+     *  ---
+     *  (parent, INDEX-2, child-1),
+     *  (parent, INDEX-2, child-2),
+     *  ...
+     */
+    _onCreateGroup: function(e) {
+        var $last = this.el.find('.scheming-subfield-group').last();
         var group = ($last.data('groupIndex') + 1) || 0;
         var $copy = $(
-          template.replace(/REPEATING-INDEX0/g, group)
+	    this.template.replace(/REPEATING-INDEX0/g, group)
           .replace(/REPEATING-INDEX1/g, group + 1));
-        $this.find('.scheming-repeating-subfields-group').append($copy);
+        this.el.find('.scheming-repeating-subfields-group').append($copy);
+
+	this.initializeModules($copy);
         $copy.hide().show(100);
         $copy.find('input').first().focus();
         // hook for late init when required for rendering polyfills
-        $this.trigger('scheming.subfield-group-init');
+        this.el.trigger('scheming.subfield-group-init');
         e.preventDefault();
-      });
+    },
 
-      $(document).on('click', 'a[name="repeating-remove"]', function(e) {
-        var $curr = $(this).closest('.scheming-subfield-group');
+    /**
+     * Remove existing group from the fieldset.
+     */
+    _onRemoveGroup: function(e) {
+        var $curr = $(e.target).closest('.scheming-subfield-group');
         var $body = $curr.find('.panel-body.fields-content');
         var $button = $curr.find('.btn-repeating-remove');
         var $removed = $curr.find('.panel-body.fields-removed-notice');
@@ -33,6 +55,15 @@ this.ckan.module('scheming-repeating-subfields', function($, _) {
           $body.html('');
         });
         e.preventDefault();
+    },
+
+    /**
+     * Enable functionality of data-module attribute inside dynamically added
+     * groups.
+     */
+    initializeModules: function(tpl) {
+      $('[data-module]', tpl).each(function (index, element) {
+        ckan.module.initializeElement(this);
       });
     }
   };


### PR DESCRIPTION
At the moment, `[data-module]` functionality works only for subfields that were rendered on page load(because CKAN initializes them).

This PR initializes `data-module` inside every subfield that was added in runtime.

I've updated js a bit in addition