### PR TITLE
CKAN 2.10 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       image: openknowledge/ckan-dev:${{ matrix.ckan-version }}
     services:
       solr:
-        image: ckan/ckan-solr-dev:${{ matrix.ckan-version }}
+        image: ckan/ckan-solr:${{ matrix.ckan-version }}
       postgres:
         image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: [2.10, 2.9, 2.9-py2, 2.8, 2.7]
+        ckan-version: ["2.10", 2.9, 2.9-py2, 2.8, 2.7]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: [master, 2.9, 2.9-py2, 2.8, 2.7]
+        ckan-version: [2.10, 2.9, 2.9-py2, 2.8, 2.7]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: [2.9, 2.9-py2, 2.8, 2.7]
+        ckan-version: [master, 2.9, 2.9-py2, 2.8, 2.7]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}

--- a/README.md
+++ b/README.md
@@ -413,13 +413,13 @@ passing the comma-separated values within as string parameters
 and the result is used as the validator/converter.
 
 ```yaml
-validators: if_empty_same_as(name) unicode
+validators: if_empty_same_as(name) unicode_safe
 ```
 
 is the same as a plugin using the validators:
 
 ```python
-[get_validator('if_empty_same_as')("name"), unicode]
+[get_validator('if_empty_same_as')("name"), unicode_safe]
 ```
 
 This string does not contain arbitrary python code to be executed,

--- a/ckanext/scheming/ckan_dataset.yaml
+++ b/ckanext/scheming/ckan_dataset.yaml
@@ -43,7 +43,7 @@ dataset_fields:
 
 - field_name: version
   label: Version
-  validators: ignore_missing unicode package_version_validator
+  validators: ignore_missing unicode_safe package_version_validator
   form_placeholder: '1.0'
 
 - field_name: author

--- a/ckanext/scheming/custom_group_with_status.json
+++ b/ckanext/scheming/custom_group_with_status.json
@@ -6,7 +6,7 @@
     {
       "field_name": "title",
       "label": "Name",
-      "validators": "ignore_missing unicode",
+      "validators": "ignore_missing unicode_safe",
       "form_snippet": "large_text.html",
       "form_attrs": {"data-module": "slug-preview-target"},
       "form_placeholder": "My theme"
@@ -14,7 +14,7 @@
     {
       "field_name": "name",
       "label": "URL",
-      "validators": "not_empty unicode name_validator group_name_validator",
+      "validators": "not_empty unicode_safe name_validator group_name_validator",
       "form_snippet": "slug.html",
       "form_placeholder": "my-theme"
     },

--- a/ckanext/scheming/custom_org_with_address.json
+++ b/ckanext/scheming/custom_org_with_address.json
@@ -6,7 +6,7 @@
     {
       "field_name": "title",
       "label": "Name",
-      "validators": "ignore_missing unicode",
+      "validators": "ignore_missing unicode_safe",
       "form_snippet": "large_text.html",
       "form_attrs": {"data-module": "slug-preview-target"},
       "form_placeholder": "My theme"
@@ -14,7 +14,7 @@
     {
       "field_name": "name",
       "label": "URL",
-      "validators": "not_empty unicode name_validator group_name_validator",
+      "validators": "not_empty unicode_safe name_validator group_name_validator",
       "form_snippet": "slug.html",
       "form_placeholder": "my-theme"
     },

--- a/ckanext/scheming/group_with_bookface.json
+++ b/ckanext/scheming/group_with_bookface.json
@@ -6,7 +6,7 @@
     {
       "field_name": "title",
       "label": "Name",
-      "validators": "ignore_missing unicode",
+      "validators": "ignore_missing unicode_safe",
       "form_snippet": "large_text.html",
       "form_attrs": {"data-module": "slug-preview-target"},
       "form_placeholder": "My Organization"
@@ -14,7 +14,7 @@
     {
       "field_name": "name",
       "label": "URL",
-      "validators": "not_empty unicode name_validator group_name_validator",
+      "validators": "not_empty unicode_safe name_validator group_name_validator",
       "form_snippet": "slug.html",
       "form_placeholder": "my-organization"
     },

--- a/ckanext/scheming/org_with_dept_id.json
+++ b/ckanext/scheming/org_with_dept_id.json
@@ -6,7 +6,7 @@
     {
       "field_name": "title",
       "label": "Name",
-      "validators": "ignore_missing unicode",
+      "validators": "ignore_missing unicode_safe",
       "form_snippet": "large_text.html",
       "form_attrs": {"data-module": "slug-preview-target"},
       "form_placeholder": "My Organization"
@@ -14,7 +14,7 @@
     {
       "field_name": "name",
       "label": "URL",
-      "validators": "not_empty unicode name_validator group_name_validator",
+      "validators": "not_empty unicode_safe name_validator group_name_validator",
       "form_snippet": "slug.html",
       "form_placeholder": "my-organization"
     },

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -434,6 +434,10 @@ class SchemingNerfIndexPlugin(p.SingletonPlugin):
     p.implements(p.IPackageController, inherit=True)
 
     def before_index(self, data_dict):
+        return self.before_dataset_index(data_dict)
+
+    def before_dataset_index(self, data_dict):
+
         schemas = SchemingDatasetsPlugin.instance._expanded_schemas
         if data_dict['type'] not in schemas:
             return data_dict

--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -6,7 +6,7 @@
     {
       "preset_name": "title",
       "values": {
-        "validators": "if_empty_same_as(name) unicode",
+        "validators": "if_empty_same_as(name) unicode_safe",
         "form_snippet": "large_text.html",
         "form_attrs": {
           "data-module": "slug-preview-target"
@@ -16,7 +16,7 @@
     {
       "preset_name": "dataset_slug",
       "values": {
-        "validators": "not_empty unicode name_validator package_name_validator",
+        "validators": "not_empty unicode_safe name_validator package_name_validator",
         "form_snippet": "slug.html"
       }
     },
@@ -36,14 +36,14 @@
     {
       "preset_name": "dataset_organization",
       "values": {
-        "validators": "owner_org_validator unicode",
+        "validators": "owner_org_validator unicode_safe",
         "form_snippet": "organization.html"
       }
     },
     {
       "preset_name": "resource_url_upload",
       "values": {
-        "validators": "ignore_missing unicode remove_whitespace",
+        "validators": "ignore_missing unicode_safe remove_whitespace",
         "form_snippet": "upload.html",
         "form_placeholder": "http://example.com/my-data.csv",
         "upload_field": "upload",
@@ -54,7 +54,7 @@
     {
       "preset_name": "organization_url_upload",
       "values": {
-        "validators": "ignore_missing unicode remove_whitespace",
+        "validators": "ignore_missing unicode_safe remove_whitespace",
         "form_snippet": "organization_upload.html",
         "form_placeholder": "http://example.com/my-data.csv"
       }
@@ -62,7 +62,7 @@
     {
       "preset_name": "resource_format_autocomplete",
       "values": {
-        "validators": "if_empty_guess_format ignore_missing clean_format unicode",
+        "validators": "if_empty_guess_format ignore_missing clean_format unicode_safe",
         "form_placeholder": "eg. CSV, XML or JSON",
         "form_attrs": {
           "data-module": "autocomplete",

--- a/ckanext/scheming/tests/test_form.py
+++ b/ckanext/scheming/tests/test_form.py
@@ -33,8 +33,13 @@ def _get_package_update_page_as_sysadmin(app, id):
 def _get_resource_new_page_as_sysadmin(app, id):
     user = Sysadmin()
     env = {"REMOTE_USER": user["name"].encode("ascii")}
+    if ckantoolkit.check_ckan_version(min_version="2.9"):
+        url = '/dataset/{}/resource/new'.format(id)
+    else:
+        url = '/dataset/new_resource/{}'.format(id)
+
     response = app.get(
-        url="/dataset/new_resource/{}".format(id), extra_environ=env
+        url, extra_environ=env
     )
     return env, response
 
@@ -42,9 +47,12 @@ def _get_resource_new_page_as_sysadmin(app, id):
 def _get_resource_update_page_as_sysadmin(app, id, resource_id):
     user = Sysadmin()
     env = {"REMOTE_USER": user["name"].encode("ascii")}
+    if ckantoolkit.check_ckan_version(min_version="2.9"):
+        url = '/dataset/{}/resource/{}/edit'.format(id, resource_id)
+    else:
+        url = '/dataset/{}/edit_resource/{}'.format(id, resource_id)
     response = app.get(
-        url="/dataset/{}/resource_edit/{}".format(id, resource_id),
-        extra_environ=env,
+        url, extra_environ=env,
     )
     return env, response
 
@@ -79,8 +87,14 @@ class TestDatasetFormNew(object):
 
     def test_resource_form_includes_custom_fields(self, app, sysadmin_env):
         dataset = Dataset(type="test-schema", name="resource-includes-custom")
+
+        if ckantoolkit.check_ckan_version(min_version="2.9"):
+            url = '/dataset/{}/resource/new'.format(dataset["id"])
+        else:
+            url = '/dataset/new_resource/{}'.format(dataset["id"])
+
         response = app.get(
-            '/dataset/new_resource/' + dataset["id"],
+            url,
             extra_environ=sysadmin_env,
         )
         form = BeautifulSoup(response.body).select_one("#resource-edit")

--- a/ckanext/scheming/tests/test_form.py
+++ b/ckanext/scheming/tests/test_form.py
@@ -50,7 +50,7 @@ def _get_resource_update_page_as_sysadmin(app, id, resource_id):
     if ckantoolkit.check_ckan_version(min_version="2.9"):
         url = '/dataset/{}/resource/{}/edit'.format(id, resource_id)
     else:
-        url = '/dataset/{}/edit_resource/{}'.format(id, resource_id)
+        url = '/dataset/{}/resource_edit/{}'.format(id, resource_id)
     response = app.get(
         url, extra_environ=env,
     )

--- a/ckanext/scheming/tests/test_helpers.py
+++ b/ckanext/scheming/tests/test_helpers.py
@@ -54,7 +54,7 @@ class TestFieldRequired(object):
         assert not scheming_field_required({"required": False})
 
     def test_not_empty_in_validators(self):
-        assert scheming_field_required({"validators": "not_empty unicode"})
+        assert scheming_field_required({"validators": "not_empty unicode_safe"})
 
     def test_not_empty_not_in_validators(self):
         assert not scheming_field_required({"validators": "maybe_not_empty"})

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -14,7 +14,8 @@ from ckantoolkit import (
     missing,
     Invalid,
     StopOnError,
-    _
+    _,
+    unicode_safe,
 )
 
 import ckanext.scheming.helpers as sh
@@ -25,6 +26,7 @@ ignore_missing = get_validator('ignore_missing')
 not_empty = get_validator('not_empty')
 
 all_validators = {}
+
 
 def register_validator(fn):
     """
@@ -43,6 +45,9 @@ def scheming_validator(fn):
     """
     fn.is_a_scheming_validator = True
     return fn
+
+
+register_validator(unicode_safe)
 
 
 @scheming_validator

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -408,8 +408,8 @@ def validators_from_string(s, field, schema):
     """
     convert a schema validators string to a list of validators
 
-    e.g. "if_empty_same_as(name) unicode" becomes:
-    [if_empty_same_as("name"), unicode]
+    e.g. "if_empty_same_as(name) unicode_safe" becomes:
+    [if_empty_same_as("name"), unicode_safe]
     """
     out = []
     parts = s.split()

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         'pyyaml',
         'ckanapi',
-        'ckantoolkit>=0.0.6',
+        'ckantoolkit>=0.0.7',
         'pytz',
         'six',
     ],

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         'pyyaml',
         'ckanapi',
-        'ckantoolkit>=0.0.2',
+        'ckantoolkit>=0.0.6',
         'pytz',
         'six',
     ],

--- a/test-requirements-py2.txt
+++ b/test-requirements-py2.txt
@@ -1,3 +1,4 @@
+six>=1.12.0
 factory-boy>=2
 mock
 soupsieve==1.2  # python2 compat beautifulsoup dep

--- a/test-requirements-py2.txt
+++ b/test-requirements-py2.txt
@@ -1,4 +1,3 @@
-six>=1.12.0
 factory-boy>=2
 mock
 soupsieve==1.2  # python2 compat beautifulsoup dep


### PR DESCRIPTION
@wardi these are changes needed to get tests passing in CKAN 2.10 (IIRC there was an issue with Boostrap 5 and the new composite fields, this PR doesn't address that).
Two things that would be good to get your take on:

1. There were some old requirements pinned in `test-requirements.txt` that don't work with Python 3.9. What do you think about unpinning them for CKAN >= 2.9? These are all CKAN core requirements too, so it's safe to assume they will be already installed (see 7451b3bad889075d6edfa6ff5233dcbafa972577)
2. The schemas included in the extension used the old `unicode` builtin function, which is no longer allowed in CKAN 2.10. Elsewhere we have replaced that by the core `unicode_safe` validator so that's what I did here as well. Alas, `unicode_safe` is not present in [CKAN 2.7](https://github.com/ckan/ckanext-scheming/runs/5817551092?check_suite_focus=true) so what do you would like to do?
  a. Drop support for CKAN 2.7
  b. Copy over the `unicode_safe` function to ckanext-scheming
  c. Copy the `unicode_safe` to ckantoolkit for fallback if using CKAN < 2.8 and use that here
  d. something else