### PR TITLE
Use a copy of fieldnames parameter in expand_form_composite function call during resource iteration.

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -298,7 +298,7 @@ class SchemingDatasetsPlugin(p.SingletonPlugin, DefaultDatasetForm,
             }
             if resource_composite and 'resources' in data_dict:
                 for res in data_dict['resources']:
-                    expand_form_composite(res, resource_composite)
+                    expand_form_composite(res, resource_composite.copy())
             # convert composite package fields to extras so they are stored
             if composite_convert_fields:
                 schema = dict(


### PR DESCRIPTION
fieldnames object is mutated during iteration over resources and so only the resource in position 0 is correctly processed. Use a copy of dict during iteration. 

Prior to this, resources at position 1:last had the format field-index-subfield in the metadata after updating rather than the expected list of dictionaries.

![image](https://user-images.githubusercontent.com/52669482/182492508-d66a50bc-45a8-4795-ad5f-fc7e0ed2119b.png)

Applicable for ckan 2.9.5 and ckanext-scheming 2.1.0.
