### PR TITLE
Add CKAN-2.10(csrf) support

### DIFF
--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -7,7 +7,7 @@ import json
 import six
 
 from jinja2 import Environment
-from ckantoolkit import config, _, check_ckan_version
+from ckantoolkit import config, _
 
 from ckanapi import LocalCKAN, NotFound, NotAuthorized
 
@@ -433,12 +433,3 @@ def scheming_flatten_subfield(subfield, data):
         for k in record:
             flat[prefix + k] = record[k]
     return flat
-
-
-@helper
-def csrf_input():
-    import ckan.plugins as p
-
-    if check_ckan_version(min_version='2.10'):
-        return p.toolkit.csrf_input()
-    return ''

--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -7,7 +7,7 @@ import json
 import six
 
 from jinja2 import Environment
-from ckantoolkit import config, _
+from ckantoolkit import config, _, check_ckan_version
 
 from ckanapi import LocalCKAN, NotFound, NotAuthorized
 
@@ -433,3 +433,12 @@ def scheming_flatten_subfield(subfield, data):
         for k in record:
             flat[prefix + k] = record[k]
     return flat
+
+
+@helper
+def csrf_input():
+    import ckan.plugins as p
+
+    if check_ckan_version(min_version='2.10'):
+        return p.toolkit.csrf_input()
+    return ''

--- a/ckanext/scheming/templates/scheming/group/group_form.html
+++ b/ckanext/scheming/templates/scheming/group/group_form.html
@@ -10,6 +10,7 @@
 {%- endif -%}
 
 <form class="dataset-form form-horizontal" method="post" data-module="basic-form" enctype="multipart/form-data">
+    {{ h.csrf_input() }}
     {%- set schema = h.scheming_get_group_schema(group_type) -%}
     {%- for field in schema['fields'] -%}
         {%- if field.form_snippet is not none -%}

--- a/ckanext/scheming/templates/scheming/organization/group_form.html
+++ b/ckanext/scheming/templates/scheming/organization/group_form.html
@@ -12,6 +12,7 @@
 {%- endif -%}
 
 <form class="dataset-form form-horizontal" method="post" data-module="basic-form" enctype="multipart/form-data">
+    {{ h.csrf_input() }}
     {%- set schema = h.scheming_get_organization_schema(group_type) -%}
     {%- for field in schema['fields'] -%}
         {%- if field.form_snippet is not none -%}
@@ -34,13 +35,13 @@
             {% block save_text %}
               {%- if action == "edit" -%}
                 {%- if 'humanize_entity_type' in h -%}
-                  {{ h.humanize_entity_type('organization', group_type, 'update label') }}
+                  {{ h.humanize_entity_type('Organization', group_type, 'update label') }}
                 {%- else -%}
                   {{ _('Update Organization') }}
                 {%- endif -%}
               {%- else -%}
                 {%- if 'humanize_entity_type' in h -%}
-                  {{ h.humanize_entity_type('organization', group_type, 'create label') }}
+                  {{ h.humanize_entity_type('Organization', group_type, 'create label') }}
                 {%- else -%}
                   {{ _('Create Organization') }}
                 {%- endif -%}

--- a/ckanext/scheming/templates/scheming/organization/group_form.html
+++ b/ckanext/scheming/templates/scheming/organization/group_form.html
@@ -35,13 +35,13 @@
             {% block save_text %}
               {%- if action == "edit" -%}
                 {%- if 'humanize_entity_type' in h -%}
-                  {{ h.humanize_entity_type('Organization', group_type, 'update label') }}
+                  {{ h.humanize_entity_type('organization', group_type, 'update label') }}
                 {%- else -%}
                   {{ _('Update Organization') }}
                 {%- endif -%}
               {%- else -%}
                 {%- if 'humanize_entity_type' in h -%}
-                  {{ h.humanize_entity_type('Organization', group_type, 'create label') }}
+                  {{ h.humanize_entity_type('organization', group_type, 'create label') }}
                 {%- else -%}
                   {{ _('Create Organization') }}
                 {%- endif -%}


### PR DESCRIPTION
We recently added `CSRF` protection in `CKAN-2.10`, all `CKAN` extensions that implement the `IBlueprint` interface are exempt, however, `ckanext-scheming` does not use blueprints  (I didn't consider it before)...
In this PR I provide a fix.