### PR TITLE
Integrate custom extra metadata

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -260,6 +260,8 @@ class SchemingDatasetsPlugin(p.SingletonPlugin, DefaultDatasetForm,
         composite_convert_fields = []
         for field_list, destination, is_dataset in fg:
             for f in field_list:
+                if is_dataset and f['field_name'] == 'extras':
+                    continue
                 convert_this = is_dataset and f['field_name'] not in schema
                 destination[f['field_name']] = get_validators(
                     f,

--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -152,6 +152,13 @@
         "display_snippet": "select.html",
         "validators": "scheming_required scheming_choices"
       }
+    },
+    {
+      "preset_name": "custom_extras",
+      "values": {
+        "form_snippet": "custom_extras.html",
+        "display_snippet": null
+      }
     }
   ]
 }

--- a/ckanext/scheming/templates/scheming/form_snippets/custom_extras.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/custom_extras.html
@@ -1,0 +1,5 @@
+
+
+
+
+{%- snippet 'snippets/custom_form_fields.html', extras=data.extras, errors=errors, limit=3 -%}

--- a/ckanext/scheming/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/additional_info.html
@@ -30,4 +30,9 @@
       <td class="dataset-details">{{ _(pkg_dict.state) }}</td>
     </tr>
   {% endif %}
+
+  {% block extras scoped %}
+    {{ super() }}
+  {% endblock %}
+
 {% endblock %}


### PR DESCRIPTION
Add a scheming preset for custom metadata key value pairs

Solution previously mentioned in #14 and  #229 has a couple issues:

- All or nothing (is enabled for all schemas)
- Incompatible with multi-page forms (fields appear on each page)
- Cannot control placement within the form

This change adds a preset using the underlying CKAN form element. The associated field must be called "extras" to bypass schema conversion. If there is a better approach please advise.