### PR TITLE
Pass dataset name to resource fields snippets

### DIFF
--- a/ckanext/scheming/templates/scheming/package/snippets/resource_form.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/resource_form.html
@@ -64,7 +64,8 @@
         errors=errors,
         licenses=c.licenses,
         entity_type='dataset',
-        object_type=dataset_type
+        object_type=dataset_type,
+        package_id=pkg_name
       -%}
     {%- endif -%}
   {%- endfor -%}

--- a/ckanext/scheming/templates/scheming/package/snippets/resource_form.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/resource_form.html
@@ -58,6 +58,8 @@
           {% do data.__setitem__(field.field_name, field.default) %}
         {% endif %}
       {% endif -%}
+      {# We pass pkg_name as the package_id because that's the only
+      variable available in this snippet #}
       {%- snippet 'scheming/snippets/form_field.html',
         field=field,
         data=data,

--- a/ckanext/scheming/templates/scheming/snippets/form_field.html
+++ b/ckanext/scheming/templates/scheming/snippets/form_field.html
@@ -13,5 +13,6 @@
   errors=errors,
   licenses=licenses,
   entity_type=entity_type,
-  object_type=object_type
+  object_type=object_type,
+  package_id=package_id
 -%}


### PR DESCRIPTION
@wardi this is just some proposal for discussion

Resource field snippets in the _new_ form have no way of knowing the dataset id/name (if it's an _edit_ form there is `data.package_id`).

These changes are not the most elegant, because 1) they add a resource-specific key to the generic `form_field.html` and 2) they pass the dataset name instead of the id.

This is because, annoyingly, upstream CKAN core only passes the name from [`new_resource.html`](https://github.com/ckan/ckan/blob/f25b7023c82d8cf65c1c30eda727142ba3a20a71/ckan/templates/package/new_resource.html#L15) / [`new_resource_not_draft.html`](https://github.com/ckan/ckan/blob/f25b7023c82d8cf65c1c30eda727142ba3a20a71/ckan/templates/package/new_resource_not_draft.html#L12) to `resource_form.html`, and not `pkg_dict`, so that's the only thing available to ckanext-scheming to pass on.

Should we patch the linked core templates to pass the whole `pkg_dict` to `resource_form.html`?
Is there a simpler approach that I'm missing?

For context, we are using this in https://github.com/frictionlessdata/ckanext-validation/pull/83, where we are creating a new frontend component to upload files that targets an endpoint that must know the dataset id to create the resource properly.