### PR TITLE
Make org_with_dept_id example match the builtin form

### DIFF
--- a/ckanext/scheming/org_with_dept_id.json
+++ b/ckanext/scheming/org_with_dept_id.json
@@ -1,14 +1,12 @@
 {
-  "scheming_version": 1,
+  "scheming_version": 2,
   "organization_type": "organization",
   "about_url": "http://github.com/ckan/ckanext-scheming",
   "fields": [
     {
       "field_name": "title",
       "label": "Name",
-      "validators": "ignore_missing unicode_safe",
-      "form_snippet": "large_text.html",
-      "form_attrs": {"data-module": "slug-preview-target"},
+      "preset": "title",
       "form_placeholder": "My Organization"
     },
     {
@@ -19,14 +17,15 @@
       "form_placeholder": "my-organization"
     },
     {
-      "field_name": "notes",
+      "field_name": "description",
       "label": "Description",
-      "form_snippet": "markdown.html",
+      "preset": "markdown",
       "form_placeholder": "A little information about my organization..."
     },
     {
-      "field_name": "url",
-      "label": "Image URL",
+      "field_name": "image_url",
+      "label": "Image",
+      "preset": "organization_url_upload",
       "form_placeholder": "http://example.com/my-image.jpg"
     },
     {


### PR DESCRIPTION
I was using this example as a reference (as I believe is the intention) when trying to add a single field to organizations without changing anything else. But the actual fields used by ckan (at least in 2.9) are named "description" and "image_url" rather than "notes" and "url". Since these are used by ckan on the organizations page, it's important they remain unchanged. So I think it would be better if the example uses the correct names.

While I was at it, I also made sure everything was using the correct preset (when available), made sure the labels matched, and increased the scheming_version to match the rest of the documentation.