### PR TITLE
Allow literal parameters in validator string

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,11 +553,11 @@ Set a `property` attribute on dataset fields displayed as "Additional Info", use
 
 ### `validators`
 
-The `validators` value is a space-separated string of validator and
-converter functions to use for this field when creating or updating data.
-When a validator name is followed by parenthesis the function is called
-passing the comma-separated values within as string parameters
-and the result is used as the validator/converter.
+The `validators` value is a space-separated string of validator and converter
+functions to use for this field when creating or updating data.  When a
+validator name is followed by parenthesis the function is called passing the
+comma-separated values within and the result is used as the
+validator/converter.
 
 ```yaml
   validators: if_empty_same_as(name) unicode_safe
@@ -567,6 +567,17 @@ is the same as a plugin using the validators:
 
 ```python
 [get_validator('if_empty_same_as')("name"), unicode_safe]
+```
+
+If parameters can be parsed as a valid python literals, they are passed with
+original type. If not, all parameters passed as strings. In addition, space
+character is not allowed in argument position. Use its HEX code instead `\\x20`.
+
+```yaml
+  validators: xxx(hello,world)    # xxx("hello", "world")
+  validators: xxx(hello,1)        # xxx("hello", "1")
+  validators: xxx("hello",1,None) # xxx("hello", 1, None)
+  validators: xxx("hello\\x20world") # xxx("hello world")
 ```
 
 This string does not contain arbitrary python code to be executed,

--- a/ckanext/scheming/tests/plugins.py
+++ b/ckanext/scheming/tests/plugins.py
@@ -6,6 +6,14 @@ class SchemingTestSubclass(SchemingDatasetsPlugin):
     pass
 
 
+class SchemingTestValidationPlugin(p.SingletonPlugin):
+    p.implements(p.IValidators)
+
+    def get_validators(self):
+        return {
+            'scheming_test_args': lambda *a: a,
+        }
+
 
 class SchemingTestSchemaPlugin(p.SingletonPlugin):
     p.implements(p.ITemplateHelpers)

--- a/ckanext/scheming/tests/test_validation.py
+++ b/ckanext/scheming/tests/test_validation.py
@@ -9,12 +9,13 @@ from ckanext.scheming.errors import SchemingException
 from ckanext.scheming.validation import (
     get_validator_or_converter,
     scheming_required,
+    validators_from_string,
 )
 from ckanext.scheming.plugins import (
     SchemingDatasetsPlugin,
     SchemingGroupsPlugin,
 )
-from ckantoolkit import get_validator, check_ckan_version
+from ckantoolkit import get_validator, check_ckan_version, navl_validate
 
 ignore_missing = get_validator("ignore_missing")
 not_empty = get_validator("not_empty")
@@ -944,3 +945,46 @@ class TestSubfieldResourceInvalid(object):
                 ].startswith("Value must be one of")
         else:
             raise AssertionError("ValidationError not raised")
+
+
+@pytest.mark.ckan_config("ckan.plugins", "scheming_test_validation")
+@pytest.mark.usefixtures("with_plugins")
+class TestValidatorsFromString:
+    def test_empty(self):
+        assert validators_from_string("", {}, {}) == []
+
+    def test_realworld_old_style(self):
+        first, second = validators_from_string("not_empty default(xxx)", {}, {})
+        assert first == not_empty
+
+        default = get_validator_or_converter("default")("xxx")
+
+        data = {
+            "empty": None,
+            "not_empty": "value"
+        }
+
+        assert navl_validate(data, {"empty": [second], "not_empty": [second]}) == navl_validate(
+            data, {"empty": [default], "not_empty": [default]}
+        )
+
+    def test_old_style_args(self):
+        result = validators_from_string("scheming_test_args(hello)", {}, {})
+        assert result == [("hello", )]
+
+        result = validators_from_string("scheming_test_args(x,y,z)", {}, {})
+        assert result == [("x","y","z")]
+
+    def test_new_style_args(self):
+
+        result = validators_from_string("scheming_test_args(1)", {}, {})
+        assert result == [(1, )]
+
+        result = validators_from_string("scheming_test_args('hello\\x20world')", {}, {})
+        assert result == [("hello world", )]
+
+        result = validators_from_string("scheming_test_args(())", {}, {})
+        assert result == [((), )]
+
+        result = validators_from_string("scheming_test_args('x',1,[None,()])", {}, {})
+        assert result == [("x", 1, [None, ()])]

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import datetime
 from collections import defaultdict
@@ -340,8 +341,18 @@ def validators_from_string(s, field, schema):
     for p in parts:
         if '(' in p and p[-1] == ')':
             name, args = p.split('(', 1)
-            args = args[:-1].split(',')  # trim trailing ')', break up
-            v = get_validator_or_converter(name)(*args)
+            args = args[:-1]  # trim trailing ')'
+            try:
+                parsed_args = ast.literal_eval(args)
+                if not isinstance(parsed_args, tuple) or not parsed_args:
+                    # it's a signle argument. `not parsed_args` means that this single
+                    # argument is an empty tuple, for example: "default(())"
+                    parsed_args = (parsed_args,)
+
+            except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
+                parsed_args = args.split(',')
+
+            v = get_validator_or_converter(name)(*parsed_args)
         else:
             v = get_validator_or_converter(p)
         if getattr(v, 'is_a_scheming_validator', False):

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -349,7 +349,7 @@ def validators_from_string(s, field, schema):
                     # argument is an empty tuple, for example: "default(())"
                     parsed_args = (parsed_args,)
 
-            except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
+            except (ValueError, TypeError, SyntaxError, MemoryError):
                 parsed_args = args.split(',')
 
             v = get_validator_or_converter(name)(*parsed_args)

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,6 @@ setup(
     scheming_nerf_index=ckanext.scheming.plugins:SchemingNerfIndexPlugin
     scheming_test_subclass=ckanext.scheming.tests.plugins:SchemingTestSubclass
     scheming_test_plugin=ckanext.scheming.tests.plugins:SchemingTestSchemaPlugin
+    scheming_test_validation=ckanext.scheming.tests.plugins:SchemingTestValidationPlugin
     """,
 )


### PR DESCRIPTION
Try parsing validator parameters using `ast.literal_eval` before naive splitting by commas.
```yaml
  # old behavior, not changed if cannot parse valid literals
  validators: xxx(hello,world)       # xxx("hello", "world")
  
  # if any argument cannot be parsed, the old strategy is used
  validators: xxx(hello,1)           # xxx("hello", "1")

  # when all arguments are valid, pass them as python objects into the validator
  validators: xxx("hello",1,None)    # xxx("hello", 1, None)

```