### PR TITLE
Fix delete URL for custom organizations

### DIFF
--- a/ckanext/scheming/templates/scheming/organization/group_form.html
+++ b/ckanext/scheming/templates/scheming/organization/group_form.html
@@ -27,7 +27,7 @@
         {% if action == 'edit' %}
           {% if h.check_access('group_delete', {'id': data.id}) and action=='edit'  %}
             {% set locale = h.dump_json({'content': _('Are you sure you want to delete this Organization?')}) %}
-            <a class="btn btn-danger pull-left" href="{% url_for controller='organization', action='delete', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+            <a class="btn btn-danger pull-left" href="{% url_for controller=group_type, action='delete', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
           {% endif %}
         {% endif %}
         {% endblock %}


### PR DESCRIPTION
There are an error deleting an organization with datasets (using a custom organization type)

Example
![image](https://github.com/okfn/ckanext-unhcr/assets/3237309/5e315d54-1e53-491a-9170-aec2ad5a9e6d)

After `manage` -> `delete`

![image](https://github.com/okfn/ckanext-unhcr/assets/3237309/e05382ad-8c1b-49db-b74e-accbeccc6958)

(my custom type is called _Data Container_)
If I go back to the container again I see _Data Container cannot be deleted while it still has datasets_

![image](https://github.com/okfn/ckanext-unhcr/assets/3237309/4edebd2e-a761-44c3-baeb-a2ac1a93dae4)


Error log

<pre>
ERROR [ckan.config.middleware.flask_app] 'organization' 
 Traceback (most recent call last): 
 File "/usr/lib/python3.8/site-packages/flask/app.py", line 1949, in full_dispatch_request |
 rv = self.dispatch_request() |
 File "/usr/lib/python3.8/site-packages/flask/app.py", line 1935, in dispatch_request 
 return self.view_functions[rule.endpoint](**req.view_args) 
 File "/srv/app/src/ckan/ckan/config/middleware/../../views/group.py", line 450, in read 
 extra_vars = _read(id, limit, group_type) |
 File "/srv/app/src/ckan/ckan/config/middleware/../../views/group.py", line 371, in _read 
 _setup_template_variables(context, {u'id': id}, group_type=group_type) |
 File "/srv/app/src/ckan/ckan/config/middleware/../../views/group.py", line 66, in _setup_template_variables 
 return lookup_group_plugin(group_type).\ 
 File "/srv/app/src/ckanext-scheming/ckanext/scheming/plugins.py", line 167, in setup_template_variables 
 c.scheming_schema = self._schemas[group_type] 
 KeyError: 'organization' 
INFO [ckan.config.middleware.flask_app] 500 /organization/container_test render time 0.294 seconds 
</pre>

This is because the `delete` button for organization goes to a bad URL
 
CKAN core generates the `delete` button URL this way: `group_type + '.delete'`

```html
<div class="form-actions">
    {% block delete_button %}
      {% if h.check_access('organization_delete', {'id': data.id})  %}

        <a class="btn btn-danger pull-left" href="{% url_for group_type+'.delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this Organization? Note*: Deleting cannot be performed while public or private datasets belong to this organization.') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>

      {% endif %}
    {% endblock %}
    <button class="btn btn-primary" name="save" type="submit">{% block save_text %}{{ _('Save Organization') }}{% endblock %}</button>
  </div>
```

https://github.com/ckan/ckan/blob/master/ckan/templates/organization/snippets/organization_form.html#L40

We need to generate the `delete` URL in the same way in this extension
 