### PR TITLE
Group Form Required Message Position

### DIFF
--- a/ckanext/scheming/templates/scheming/organization/group_form.html
+++ b/ckanext/scheming/templates/scheming/organization/group_form.html
@@ -22,6 +22,8 @@
         {%- endif -%}
     {%- endfor -%}
 
+    {{ form.required_message() }}
+
     <div class="form-actions">
         {% block delete_button %}
         {% if action == 'edit' %}
@@ -48,6 +50,5 @@
               {%- endif -%}
             {% endblock %}
         </button>
-        {{ form.required_message() }}
     </div>
 </form>


### PR DESCRIPTION
fix(templates): form required message position;

- Moved `required_message` macro call outside of `form-actions` div;
- Aligned macro call with core template behavior.