### PR TITLE
Fix output validators parsing when repeating_subfields

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -574,8 +574,15 @@ def _field_output_validators(f, schema, convert_extras,
     else:
         validators = [ignore_missing]
     if 'output_validators' in f:
-        validators += validation.validators_from_string(
-            f['output_validators'], f, schema)
+        if isinstance(validators, list):
+            validators += validation.validators_from_string(
+                f['output_validators'], f, schema
+            )
+        else:
+            validators.update({
+                f['field_name']: validation.validators_from_string(
+                f['output_validators'], f, schema
+            )})
     return validators
 
 


### PR DESCRIPTION
## Error

Currently if `repeating_subfields` are used with an `output_validator`, then an error is raised during validator concatenation:

```
2023-08-04 07:28:58,146.146 [ERROR] ckan.lib.search | rebuild:210 | Traceback (most recent call last):
  File "/usr/lib/ckan/.local/lib/python3.9/site-packages/ckan/lib/search/__init__.py", line 200, in rebuild
    package_index.update_dict(
  File "/usr/lib/ckan/.local/lib/python3.9/site-packages/ckan/lib/search/index.py", line 109, in update_dict
    self.index_package(pkg_dict, defer_commit)
  File "/usr/lib/ckan/.local/lib/python3.9/site-packages/ckan/lib/search/index.py", line 127, in index_package
    validated_pkg_dict, errors = lib_plugins.plugin_validate(
  File "/usr/lib/ckan/.local/lib/python3.9/site-packages/ckan/lib/plugins.py", line 312, in plugin_validate
    result = plugin.validate(context, data_dict, schema, action)
  File "/usr/lib/ckan/.local/lib/python3.9/site-packages/ckanext/scheming/plugins.py", line 264, in validate
    destination[f['field_name']] = get_validators(
  File "/usr/lib/ckan/.local/lib/python3.9/site-packages/ckanext/scheming/plugins.py", line 577, in _field_output_validators
    validators += validation.validators_from_string(
TypeError: unsupported operand type(s) for +=: 'dict' and 'list'
```

## Issue

The source of the error (trying to add dict subfield validators to list of field validators):

https://github.com/ckan/ckanext-scheming/blob/8646a9dce79aa0b5a46274271ca6330dc0870b92/ckanext/scheming/plugins.py#L576-L578


## Solution

This PR adds a type check and appends the field validator as a list if no subfields, or as a dict if subfields:

```python
    if 'output_validators' in f:
        if isinstance(validators, list):
            validators += validation.validators_from_string(
                f['output_validators'], f, schema
            )
        else:
            validators.update({
                f['field_name']: validation.validators_from_string(
                f['output_validators'], f, schema
            )})
```