### PR TITLE
Handle empty multiple_checkbox

### DIFF
--- a/ckanext/scheming/templates/scheming/form_snippets/multiple_checkbox.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/multiple_checkbox.html
@@ -27,6 +27,11 @@ fieldset.checkboxes label input {
   {%- if field.get('sorted_choices') -%}
     {%- set choices = choices|sort(case_sensitive=false, attribute=1) -%}
   {%- endif -%}
+    <input
+        type="hidden"
+        name="{{ field.field_name }}"
+        value=""
+    />
     <fieldset class="checkboxes">
         {%- for val, label in choices -%}
             <label for="field-{{ field.field_name }}-{{ val }}">

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -139,6 +139,8 @@ def scheming_multiple_choice(field, schema):
             if element in choice_values:
                 selected.add(element)
                 continue
+            if element == "":
+                continue
             errors[key].append(_('unexpected choice "%s"') % element)
 
         if not errors[key]:


### PR DESCRIPTION
Fix #387.

I am not even sure if the "required" check code if ever run, since the validator is not executed when the field is missing when handling `package_patch`:

https://github.com/ckan/ckanext-scheming/blob/8646a9dce79aa0b5a46274271ca6330dc0870b92/ckanext/scheming/validation.py#L152-L153

Therefore, I guess this patch should also fix this issue as well, since the validator should always be triggered. I have not tested it, though.