### PR TITLE
[Fix #398] Add `form-select` CSS class to `select` elements

### DIFF
--- a/ckanext/scheming/templates/scheming/form_snippets/datetime_tz.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/datetime_tz.html
@@ -55,7 +55,7 @@
     selected=tz,
     error=errors[field.field_name + '_tz'],
     classes=field.classes if 'classes' in field else ['control-medium'],
-    attrs=dict({"class": "form-control"}, **(field.get('form_attrs', {}))),
+    attrs=dict({"class": "form-control form-select"}, **(field.get('form_attrs', {}))),
     is_required=h.scheming_field_required(field)
     )
 %}

--- a/ckanext/scheming/templates/scheming/form_snippets/organization.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/organization.html
@@ -24,7 +24,7 @@
     <div class="control-group form-group control-medium">
       <label for="field-private" class="control-label">{{ _('Visibility') }}</label>
       <div class="controls">
-        <select id="field-private" name="private" class="form-control">
+        <select id="field-private" name="private" class="form-control form-select">
           {% for option in [('True', _('Private')), ('False', _('Public'))] %}
           <option value="{{ option[0] }}" {% if option[0] == data.private|trim %}selected="selected"{% endif %}>{{ option[1] }}</option>
           {% endfor %}

--- a/ckanext/scheming/templates/scheming/form_snippets/select.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/select.html
@@ -30,7 +30,7 @@
     selected=option_selected,
     error=errors[field.field_name],
     classes=field.classes if 'classes' in field else ['control-medium'],
-    attrs=dict({"class": "form-control"}, **(field.get('form_attrs', {}))),
+    attrs=dict({"class": "form-control form-select"}, **(field.get('form_attrs', {}))),
     is_required=h.scheming_field_required(field)
     )
 %}


### PR DESCRIPTION
## Overview

This PR addresses #398. It integrates the `form-select` CSS class with various `select` elements in the `form_snippets` directory. This causes the select elements to be rendered consistently with other dropdown menus in the CKAN UI.

## Changes

* Add `form-select` to "class" attribute when invoking `form.select()` macro in `form_snippets/select.html` and `form_snippets/datetime_tz.html`
* Add `form-select` to class on hardcoded `select` element in `form_snippets/organization.html`