### PR TITLE
Add the ability to create an arbitrary schema for rendering elsewhere

### DIFF
--- a/ckanext/scheming/arbitrary_schema_example.yaml
+++ b/ckanext/scheming/arbitrary_schema_example.yaml
@@ -1,0 +1,27 @@
+scheming_version: 2
+schema_id: ckanext_notifier
+about: An example of a config schema for a fictional extension
+
+fields:
+  - field_name: ckanext.ckanext_notifier.enable_notifications
+    label: Enable notifications
+    validators: default(true) boolean_validator
+    preset: select
+    required: true
+    choices:
+      - value: true
+        label: Enable
+      - value: false
+        label: Disable
+
+  - field_name: ckanext.ckanext_notifier.notify_to_email
+    label: Notification email
+    validators: unicode_safe email_validator
+    required: true
+    help_text: Specify the email address to which the notification will be sent
+
+  - field_name: ckanext.ckanext_notifier.frequency
+    label: Notification frequency in seconds
+    validators: default(3600) int_validator
+    required: true
+    input_type: number

--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -445,3 +445,28 @@ def scheming_flatten_subfield(subfield, data):
         for k in record:
             flat[prefix + k] = record[k]
     return flat
+
+
+@helper
+def scheming_arbitrary_schemas(expanded=True):
+    """
+    Return the dict of arbitrary schemas. Or if scheming_arbitrary
+    plugin is not loaded return None.
+    """
+    from ckanext.scheming.plugins import SchemingArbitraryPlugin as plugin
+
+    if plugin.instance:
+        if expanded:
+            return plugin.instance._expanded_schemas
+        return plugin.instance._schemas
+
+    return {}
+
+
+@helper
+def scheming_get_arbitrary_schema(schema_id, expanded=True):
+    """
+    Return the schema for the schema_id passed or None if
+    no schema is defined for that schema_id.
+    """
+    return scheming_arbitrary_schemas(expanded).get(schema_id)

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -473,6 +473,17 @@ class SchemingOrganizationsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,
                 logic.scheming_organization_schema_show,
         }
 
+class SchemingArbitraryPlugin(p.SingletonPlugin, _SchemingMixin):
+    p.implements(p.IConfigurer)
+
+    SCHEMA_OPTION = "scheming.arbitrary_schemas"
+    FALLBACK_OPTION = 'scheming.arbitrary_fallback'
+    SCHEMA_TYPE_FIELD = "schema_id"
+
+    @classmethod
+    def _store_instance(cls, self):
+        SchemingArbitraryPlugin.instance = self
+
 
 class SchemingNerfIndexPlugin(p.SingletonPlugin):
     """

--- a/ckanext/scheming/templates/scheming/group/group_form.html
+++ b/ckanext/scheming/templates/scheming/group/group_form.html
@@ -12,13 +12,7 @@
 <form class="dataset-form form-horizontal" method="post" data-module="basic-form" enctype="multipart/form-data">
     {{ h.csrf_input() if 'csrf_input' in h }}
     {%- set schema = h.scheming_get_group_schema(group_type) -%}
-    {%- for field in schema['fields'] -%}
-        {%- if field.form_snippet is not none -%}
-          {%- snippet 'scheming/snippets/form_field.html',
-          field=field, data=data, errors=errors, licenses=licenses,
-          entity_type='group', object_type=group_type -%}
-        {%- endif -%}
-    {%- endfor -%}
+    {% snippet 'scheming/snippets/render_fields.html', fields=schema.fields, data=data, errors=errors, entity_type='group', object_type=group_type %}
 
     <div class="form-actions">
         {% block delete_button %}

--- a/ckanext/scheming/templates/scheming/organization/group_form.html
+++ b/ckanext/scheming/templates/scheming/organization/group_form.html
@@ -14,13 +14,7 @@
 <form class="dataset-form form-horizontal" method="post" data-module="basic-form" enctype="multipart/form-data">
     {{ h.csrf_input() if 'csrf_input' in h }}
     {%- set schema = h.scheming_get_organization_schema(group_type) -%}
-    {%- for field in schema['fields'] -%}
-        {%- if field.form_snippet is not none -%}
-          {%- snippet 'scheming/snippets/form_field.html',
-          field=field, data=data, errors=errors, licenses=licenses,
-          entity_type='organization', object_type=group_type -%}
-        {%- endif -%}
-    {%- endfor -%}
+    {% snippet 'scheming/snippets/render_fields.html', fields=schema.fields, data=data, errors=errors, entity_type='organization', object_type=group_type %}
 
     {{ form.required_message() }}
 

--- a/ckanext/scheming/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/package_form.html
@@ -68,30 +68,8 @@
   {%- else -%}
     {%- set fields = schema.dataset_fields -%}
   {%- endif -%}
-  {%- for field in fields -%}
-    {%- if field.form_snippet is not none -%}
-      {%- if field.field_name not in data %}
-        {# Set the field default value before rendering but only if
-        it doesn't already exist in data which would mean the form
-        has been submitted. #}
-        {% if field.default_jinja2 %}
-          {% do data.__setitem__(
-            field.field_name,
-            h.scheming_render_from_string(field.default_jinja2)) %}
-        {% elif field.default %}
-          {% do data.__setitem__(field.field_name, field.default) %}
-        {% endif %}
-      {% endif -%}
-      {%- snippet 'scheming/snippets/form_field.html',
-        field=field,
-        data=data,
-        errors=errors,
-        licenses=c.licenses,
-        entity_type='dataset',
-        object_type=dataset_type
-      -%}
-    {%- endif -%}
-  {%- endfor -%}
+
+  {% snippet 'scheming/snippets/render_fields.html', fields=schema.dataset_fields, data=data, errors=errors, entity_type='dataset', object_type=dataset_type, set_fields_defaults=true %}
 
   {%- if pages -%}
     <input type="hidden" name="_ckan_phase" value="{{ active_page }}" />

--- a/ckanext/scheming/templates/scheming/package/snippets/resource_form.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/resource_form.html
@@ -47,34 +47,7 @@
   {%- endif -%}
 
   {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
-  {%- for field in schema.resource_fields -%}
-    {%- if field.form_snippet is not none -%}
-      {%- if field.field_name not in data %}
-        {# Set the field default value before rendering but only if
-        it doesn't already exist in data which would mean the form
-        has been submitted. #}
-        {% if field.default_jinja2 %}
-          {% do data.__setitem__(
-            field.field_name,
-            h.scheming_render_from_string(field.default_jinja2)) %}
-        {% elif field.default %}
-          {% do data.__setitem__(field.field_name, field.default) %}
-        {% endif %}
-      {% endif -%}
-      {# We pass pkg_name as the package_id because that's the only
-      variable available in this snippet #}
-      {%- snippet 'scheming/snippets/form_field.html',
-        field=field,
-        data=data,
-        errors=errors,
-        licenses=c.licenses,
-        entity_type='dataset',
-        object_type=dataset_type,
-        package_id=pkg_name
-      -%}
-    {%- endif -%}
-  {%- endfor -%}
-
+  {% snippet 'scheming/snippets/render_fields.html', fields=schema.resource_fields, data=data, errors=errors, entity_type='dataset', object_type=dataset_type, set_fields_defaults=true %}
 {% endblock %}
 
 

--- a/ckanext/scheming/templates/scheming/snippets/render_fields.html
+++ b/ckanext/scheming/templates/scheming/snippets/render_fields.html
@@ -1,0 +1,30 @@
+{#}
+    fields - a list of scheming field dictionaries
+    data - form data fields
+    errors - A dict of errors for the fields
+    entity_type - entity type
+    object_type - object type
+    set_fields_defaults - flag to set the default field values
+{#}
+
+{% for field in fields if field.form_snippet is not none %}
+    {% if field.field_name not in data and set_fields_defaults %}
+        {# Set the field default value before rendering but only if
+        it doesn't already exist in data which would mean the form
+        has been submitted. #}
+        {% if field.default_jinja2 %}
+            {% do data.__setitem__(field.field_name, h.scheming_render_from_string(field.default_jinja2)) %}
+        {% elif field.default %}
+            {% do data.__setitem__(field.field_name, field.default) %}
+        {% endif %}
+    {% endif %}
+
+    {% snippet 'scheming/snippets/form_field.html',
+        field=field,
+        data=data,
+        errors=errors,
+        licenses=licenses,
+        entity_type=entity_type,
+        object_type=object_type
+    %}
+{% endfor %}

--- a/ckanext/scheming/tests/test_arbitrary_schema.py
+++ b/ckanext/scheming/tests/test_arbitrary_schema.py
@@ -1,0 +1,30 @@
+import pytest
+from flask import render_template
+from bs4 import BeautifulSoup
+
+from ckanext.scheming.helpers import scheming_get_arbitrary_schema
+
+
+class TestArbitrarySchema:
+    def test_arbitrary_schema_structure(self):
+        schema = scheming_get_arbitrary_schema("ckanext_notifier")
+
+        assert schema["scheming_version"]
+        assert schema["schema_id"] == "ckanext_notifier"
+        assert schema["about"]
+        assert isinstance(schema["fields"], list)
+
+    @pytest.mark.usefixtures("with_request_context")
+    def test_render_arbitrary_schema(self, app):
+        schema = scheming_get_arbitrary_schema("ckanext_notifier")
+
+        result = render_template(
+            "scheming/snippets/render_fields.html",
+            fields=schema["fields"],
+            data={},
+            errors={},
+        )
+
+        soup = BeautifulSoup(result)
+
+        assert len(soup.select("div.form-group")) == 3

--- a/ckanext/scheming/tests/test_helpers.py
+++ b/ckanext/scheming/tests/test_helpers.py
@@ -6,6 +6,8 @@ except ImportError:
     from mock import patch, Mock
 
 import datetime
+
+import pytest
 import six
 
 from ckanext.scheming.helpers import (
@@ -15,6 +17,8 @@ from ckanext.scheming.helpers import (
     scheming_get_presets,
     scheming_datastore_choices,
     scheming_display_json_value,
+    scheming_get_arbitrary_schema,
+    scheming_arbitrary_schemas,
 )
 
 from ckanapi import NotFound
@@ -27,9 +31,7 @@ class TestLanguageText(object):
         assert "hello1" == scheming_language_text("hello")
 
     def test_only_one_language(self):
-        assert "hello" == scheming_language_text(
-            {"zh": "hello"}, prefer_lang="en"
-        )
+        assert "hello" == scheming_language_text({"zh": "hello"}, prefer_lang="en")
 
     def test_matching_language(self):
         assert "hello" == scheming_language_text(
@@ -42,7 +44,7 @@ class TestLanguageText(object):
         )
 
     def test_decodes_utf8(self):
-        assert u"\xa1Hola!" == scheming_language_text(six.b("\xc2\xa1Hola!"))
+        assert "\xa1Hola!" == scheming_language_text(six.b("\xc2\xa1Hola!"))
 
     @patch("ckanext.scheming.helpers.lang")
     def test_no_user_lang(self, lang):
@@ -69,35 +71,35 @@ class TestGetPreset(object):
         presets = scheming_get_presets()
         assert sorted(
             (
-                u'title',
-                u'tag_string_autocomplete',
-                u'select',
-                u'resource_url_upload',
-                u'organization_url_upload',
-                u'resource_format_autocomplete',
-                u'multiple_select',
-                u'multiple_checkbox',
-                u'multiple_text',
-                u'date',
-                u'datetime',
-                u'datetime_tz',
-                u'dataset_slug',
-                u'dataset_organization',
-                u'json_object',
-                u'markdown',
-                u'radio',
+                "title",
+                "tag_string_autocomplete",
+                "select",
+                "resource_url_upload",
+                "organization_url_upload",
+                "resource_format_autocomplete",
+                "multiple_select",
+                "multiple_checkbox",
+                "multiple_text",
+                "date",
+                "datetime",
+                "datetime_tz",
+                "dataset_slug",
+                "dataset_organization",
+                "json_object",
+                "markdown",
+                "radio",
             )
         ) == sorted(presets.keys())
 
     def test_scheming_get_preset(self):
-        preset = scheming_get_preset(u"date")
+        preset = scheming_get_preset("date")
         assert sorted(
             (
-                (u"display_snippet", u"date.html"),
-                (u"form_snippet", u"date.html"),
+                ("display_snippet", "date.html"),
+                ("form_snippet", "date.html"),
                 (
-                    u"validators",
-                    u"scheming_required isodate convert_to_json_if_date",
+                    "validators",
+                    "scheming_required isodate convert_to_json_if_date",
                 ),
             )
         ) == sorted(preset.items())
@@ -110,9 +112,7 @@ class TestDatastoreChoices(object):
         lc.action.datastore_search.side_effect = NotFound()
         LocalCKAN.return_value = lc
         assert (
-            scheming_datastore_choices(
-                {"datastore_choices_resource": "not-found"}
-            )
+            scheming_datastore_choices({"datastore_choices_resource": "not-found"})
             == []
         )
         lc.action.datastore_search.assert_called_once()
@@ -123,9 +123,7 @@ class TestDatastoreChoices(object):
         lc.action.datastore_search.side_effect = NotFound()
         LocalCKAN.return_value = lc
         assert (
-            scheming_datastore_choices(
-                {"datastore_choices_resource": "not-allowed"}
-            )
+            scheming_datastore_choices({"datastore_choices_resource": "not-allowed"})
             == []
         )
         lc.action.datastore_search.assert_called_once()
@@ -136,9 +134,7 @@ class TestDatastoreChoices(object):
         lc.action.datastore_search.side_effect = NotFound()
         LocalCKAN.return_value = lc
         assert (
-            scheming_datastore_choices(
-                {"datastore_choices_resource": "not-allowed"}
-            )
+            scheming_datastore_choices({"datastore_choices_resource": "not-allowed"})
             == []
         )
         lc.action.datastore_search.assert_called_once()
@@ -175,9 +171,10 @@ class TestDatastoreChoices(object):
                 "datastore_choices_resource": "all-params",
                 "datastore_choices_limit": 5,
                 "datastore_choices_columns": {"value": "a", "label": "b"},
-                "datastore_additional_choices":
-                    [{"value": "none", "label": "None"},
-                     {"value": "na", "label": "N/A"}]
+                "datastore_additional_choices": [
+                    {"value": "none", "label": "None"},
+                    {"value": "na", "label": "N/A"},
+                ],
             }
         ) == [
             {"value": "none", "label": "None"},
@@ -194,41 +191,56 @@ class TestDatastoreChoices(object):
 
 class TestJSONHelpers(object):
     def test_display_json_value_default(self):
-
         value = {"a": "b"}
 
         assert scheming_display_json_value(value) == '{\n  "a": "b"\n}'
 
     def test_display_json_value_indent(self):
-
         value = {"a": "b"}
 
-        assert (
-            scheming_display_json_value(value, indent=4)
-            == '{\n    "a": "b"\n}'
-        )
+        assert scheming_display_json_value(value, indent=4) == '{\n    "a": "b"\n}'
 
     def test_display_json_value_no_indent(self):
-
         value = {"a": "b"}
 
         assert scheming_display_json_value(value, indent=None) == '{"a": "b"}'
 
     def test_display_json_value_keys_are_sorted(self):
-
         value = {"c": "d", "a": "b"}
         if six.PY3:
             expected = '{\n    "a": "b",\n    "c": "d"\n}'
         else:
             expected = '{\n    "a": "b", \n    "c": "d"\n}'
 
-        assert (
-            scheming_display_json_value(value, indent=4) == expected
-        )
+        assert scheming_display_json_value(value, indent=4) == expected
 
     def test_display_json_value_json_error(self):
-
         date = datetime.datetime.now()
         value = ("a", date)
 
         assert scheming_display_json_value(value) == ("a", date)
+
+
+@pytest.mark.usefixtures("with_plugins")
+class TestGetArbitrarySchemaHelper(object):
+    def test_get_all_arbitrary_schemas(self):
+        schemas = scheming_arbitrary_schemas()
+
+        assert schemas
+
+    @pytest.mark.ckan_config("scheming.arbitrary_schemas", "")
+    def test_get_all_arbitrary_schemas_if_none(self):
+        schemas = scheming_arbitrary_schemas()
+
+        assert not schemas
+
+    def test_get_specific_schema(self):
+        schema = scheming_get_arbitrary_schema("ckanext_notifier")
+
+        assert schema
+
+    @pytest.mark.ckan_config("scheming.arbitrary_schemas", "")
+    def test_get_specific_schema_if_none(self):
+        schema = scheming_get_arbitrary_schema("ckanext_notifier")
+
+        assert not schema

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '3.0.0'
+version = '3.0.1'
 
 setup(
     name='ckanext-scheming',
@@ -37,6 +37,7 @@ setup(
     scheming_datasets=ckanext.scheming.plugins:SchemingDatasetsPlugin
     scheming_groups=ckanext.scheming.plugins:SchemingGroupsPlugin
     scheming_organizations=ckanext.scheming.plugins:SchemingOrganizationsPlugin
+    scheming_arbitrary=ckanext.scheming.plugins:SchemingArbitraryPlugin
     scheming_nerf_index=ckanext.scheming.plugins:SchemingNerfIndexPlugin
     scheming_test_subclass=ckanext.scheming.tests.plugins:SchemingTestSubclass
     scheming_test_plugin=ckanext.scheming.tests.plugins:SchemingTestSchemaPlugin

--- a/test.ini
+++ b/test.ini
@@ -12,7 +12,7 @@ port = 5000
 use = config:../../src/ckan/test-core.ini
 
 ckan.plugins = scheming_datasets scheming_groups scheming_organizations
-               scheming_test_plugin scheming_nerf_index
+               scheming_test_plugin scheming_nerf_index scheming_arbitrary
 scheming.dataset_schemas = ckanext.scheming:ckan_dataset.yaml
                            ckanext.scheming.tests:test_schema.json
 			   ckanext.scheming.tests:test_subfields.yaml
@@ -21,6 +21,7 @@ scheming.organization_schemas = ckanext.scheming:org_with_dept_id.json
                                 ckanext.scheming:custom_org_with_address.json
 scheming.group_schemas = ckanext.scheming:group_with_bookface.json
                          ckanext.scheming:custom_group_with_status.json
+scheming.arbitrary_schemas = ckanext.scheming:arbitrary_schema_example.yaml
 
 ckan.site_logo = /img/logo_64px_wide.png
 ckan.favicon = /images/icons/ckan.ico


### PR DESCRIPTION
Right now I'm working on an extended admin panel and I need to create several configurational pages for different plugins. Since we are using `ckanext-scheming` for all of our CKAN projects, I assume it's a good idea to make it more flexible.

The plugin is oriented toward creating a schema for predefined entity types (dataset, group & organization), but it already has the power to make much more. I suggest allowing defining arbitrary schemas with a unique `schema_id`. This schema could be rendered as independent fields with a `render_fields.html` snippet.

It's defined as a separate extension inside `ckanext-scheming`, that must be enabled to work with (same as other parts of the scheming). The schema follows the **same format** as group & organization schemas, except for the `schema_id` field. That is a unique identifier of a schema. Example of a schema:
```
scheming_version: 2
schema_id: ckanext_notifier
about: An example of a config schema for a fictional extension

fields:
  - field_name: ckanext.ckanext_notifier.enable_notifications
    label: Enable notifications
    validators: default(true) boolean_validator
    preset: select
    required: true
    choices:
      - value: true
        label: Enable
      - value: false
        label: Disable

  - field_name: ckanext.ckanext_notifier.notify_to_email
    label: Notification email
    validators: unicode_safe email_validator
    required: true
    help_text: Specify the email address to which the notification will be sent

  - field_name: ckanext.ckanext_notifier.frequency
    label: Notification frequency in seconds
    validators: default(3600) int_validator
    required: true
    input_type: number
```

When the schema is created and registered via CKAN config, we can fetch it with a `scheming_get_arbitrary_schema` helper. Then in a template, we can render a form like this:
```
<form method="POST">
    {% snippet 'scheming/snippets/render_fields.html', fields=schema.fields, data=data, errors=errors %}

    <button type="submit" class="btn btn-primary">{{ _('Update') }}</button>
</form>
```
And get the next result:
![image](https://github.com/ckan/ckanext-scheming/assets/55234934/c6b7d2a9-ad84-4db8-a571-4f30e311e04a)
_I wrote tests but didn't update the documentation yet. I'm going to do it if we are fine with those changes._