### PR TITLE
Support for CKAN 2.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     name: CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest
     container:
-      image: openknowledge/ckan-dev:${{ matrix.ckan-version }}
+      image: ckan/ckan-dev:${{ matrix.ckan-version }}
     services:
       solr:
         image: ckan/ckan-solr:${{ matrix.ckan-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: ["2.10", "2.9", "2.9-py2"]
+        ckan-version: ["master", "2.10", "2.9", "2.9-py2"]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.7'
       - name: Install requirements
@@ -44,7 +44,7 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install requirements
       run: |
         pip install -e .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: ["master", "2.10", "2.9", "2.9-py2"]
+        ckan-version: ["master", "2.10", "2.9"]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: ["master", "2.10", "2.9"]
+        ckan-version: ["2.11", "2.10", "2.9"]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}
@@ -26,7 +26,7 @@ jobs:
       image: ckan/ckan-dev:${{ matrix.ckan-version }}
     services:
       solr:
-        image: ckan/ckan-solr:${{ matrix.ckan-version }}
+        image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr9
       postgres:
         image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
         env:

--- a/ckanext/scheming/tests/test_validation.py
+++ b/ckanext/scheming/tests/test_validation.py
@@ -21,6 +21,22 @@ ignore_missing = get_validator("ignore_missing")
 not_empty = get_validator("not_empty")
 
 
+pytestmark = [
+    pytest.mark.usefixtures("with_plugins"),
+    pytest.mark.ckan_config(
+        "ckan.plugins",
+        " ".join([
+            "scheming_datasets",
+            "scheming_groups",
+            "scheming_organizations",
+            "scheming_test_plugin",
+            "scheming_subfields_index",
+            "scheming_test_validation",
+        ])
+    )
+]
+
+
 class TestGetValidatorOrConverter(object):
     def test_missing(self):
         with pytest.raises(SchemingException):
@@ -941,8 +957,6 @@ class TestSubfieldResourceInvalid(object):
             raise AssertionError("ValidationError not raised")
 
 
-@pytest.mark.ckan_config("ckan.plugins", "scheming_test_validation")
-@pytest.mark.usefixtures("with_plugins")
 class TestValidatorsFromString:
     def test_empty(self):
         assert validators_from_string("", {}, {}) == []

--- a/ckanext/scheming/tests/test_validation.py
+++ b/ckanext/scheming/tests/test_validation.py
@@ -30,7 +30,7 @@ pytestmark = [
             "scheming_groups",
             "scheming_organizations",
             "scheming_test_plugin",
-            "scheming_subfields_index",
+            "scheming_nerf_index",
             "scheming_test_validation",
         ])
     )


### PR DESCRIPTION
Freshen up the worflow file and adapt tests to changes in test client authentication in CKAN 2.11
Starting from CKAN 2.11 test client calls are authenticated via `headers={"Authorization": token}` rather than `environ_overrides={"Authorization": token}`. I added some helper functions to handle different CKAN versions from a single place. Also there is a new form in the page so index-based selectors needed to be updated.

More details on the auth changes here:
https://github.com/ckan/ckan/wiki/CKAN-2.10-to-2.11-migration-tips#authentication-when-using-the-test-client