### PR TITLE
Provide a new plugin for indexing repeating subfields

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,10 +280,13 @@ When using a plain string translations will be provided with gettext:
 This field is the parent of group of repeating subfields. The value is
 a list of fields entered the same way as normal fields.
 
-> **_NOTE:_** CKAN needs an IPackageController plugin with `before_index` to
-> convert repeating subfields to formats that can be indexed by solr. For
-> testing you may use the included `scheming_nerf_index` plugin to encode
-> all repeating fields as JSON strings to prevent solr errors.
+> [!NOTE]
+> CKAN needs an IPackageController plugin with `before_dataset_index` to
+> convert repeating subfields to formats that can be indexed by solr. The
+> included `scheming_subfields_index` plugin will group the values of the
+> same subfields in a text field that will make the values findable. If
+> you require more precise handling of a particular subfield,
+> you will need to customize the Solr schema to add the necessary fields.
 
 `repeating_label` may be used to provide a singular version of the label
 for each group.

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -533,7 +533,9 @@ class SchemingSubfieldsIndexPlugin(p.SingletonPlugin):
                         if isinstance(value, list):
                             value = ' '.join(value)
                         # Index a flattened version
-                        new_key = f'extras_{field["field_name"]}__{key}'
+                        new_key = 'extras_{field_name}__{key}'.format(
+                            field_name=field["field_name"], key=key
+                        )
                         if not data_dict.get(new_key):
                             data_dict[new_key] = value
                         else:

--- a/ckanext/scheming/tests/test_subfields.py
+++ b/ckanext/scheming/tests/test_subfields.py
@@ -19,6 +19,7 @@ dataset_dict = {
 
 
 @pytest.mark.usefixtures("with_plugins", "clean_db")
+@pytest.mark.ckan_config("ckan.plugins", "scheming_datasets scheming_subfields_index")
 def test_repeating_subfields_index():
 
     with mock.patch("ckan.lib.search.index.make_connection") as m:
@@ -31,6 +32,7 @@ def test_repeating_subfields_index():
 
 
 @pytest.mark.usefixtures("with_plugins", "clean_db")
+@pytest.mark.ckan_config("ckan.plugins", "scheming_datasets scheming_subfields_index")
 def test_repeating_subfields_search():
 
     dataset = call_action("package_create", **dataset_dict)

--- a/ckanext/scheming/tests/test_subfields.py
+++ b/ckanext/scheming/tests/test_subfields.py
@@ -1,4 +1,7 @@
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import pytest
 import ckantoolkit

--- a/ckanext/scheming/tests/test_subfields.py
+++ b/ckanext/scheming/tests/test_subfields.py
@@ -1,0 +1,40 @@
+from unittest import mock
+
+import pytest
+import ckantoolkit
+
+from ckantoolkit.tests.factories import Dataset
+from ckantoolkit.tests.helpers import call_action
+
+
+dataset_dict = {
+    "name": "test-dataset",
+    "type": "test-subfields",
+    # Repeating subfields
+    "contact_address": [
+        {"address": "Maple Street 123", "city": "New Paris", "country": "Maplonia"},
+        {"address": "Rose Avenue 452", "city": "Old York", "country": "Rosestan"},
+    ],
+}
+
+
+@pytest.mark.usefixtures("with_plugins", "clean_db")
+def test_repeating_subfields_index():
+
+    with mock.patch("ckan.lib.search.index.make_connection") as m:
+        call_action("package_create", **dataset_dict)
+
+        # Dict sent to Solr
+        search_dict = m.mock_calls[1].kwargs["docs"][0]
+        assert search_dict["extras_contact_address__city"] == "New Paris Old York"
+        assert search_dict["extras_contact_address__country"] == "Maplonia Rosestan"
+
+
+@pytest.mark.usefixtures("with_plugins", "clean_db")
+def test_repeating_subfields_search():
+
+    dataset = call_action("package_create", **dataset_dict)
+
+    result = call_action("package_search", q="Old York")
+
+    assert result["results"][0]["id"] == dataset["id"]

--- a/ckanext/scheming/tests/test_validation.py
+++ b/ckanext/scheming/tests/test_validation.py
@@ -21,6 +21,22 @@ ignore_missing = get_validator("ignore_missing")
 not_empty = get_validator("not_empty")
 
 
+pytestmark = [
+    pytest.mark.usefixtures("with_plugins"),
+    pytest.mark.ckan_config(
+        "ckan.plugins",
+        " ".join([
+            "scheming_datasets",
+            "scheming_groups",
+            "scheming_organizations",
+            "scheming_test_plugin",
+            "scheming_subfields_index",
+            "scheming_test_validation",
+        ])
+    )
+]
+
+
 class TestGetValidatorOrConverter(object):
     def test_missing(self):
         with pytest.raises(SchemingException):
@@ -941,8 +957,6 @@ class TestSubfieldResourceInvalid(object):
             raise AssertionError("ValidationError not raised")
 
 
-@pytest.mark.ckan_config("ckan.plugins", "scheming_test_validation")
-@pytest.mark.usefixtures("with_plugins")
 class TestValidatorsFromString:
     def test_empty(self):
         assert validators_from_string("", {}, {}) == []

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     scheming_groups=ckanext.scheming.plugins:SchemingGroupsPlugin
     scheming_organizations=ckanext.scheming.plugins:SchemingOrganizationsPlugin
     scheming_nerf_index=ckanext.scheming.plugins:SchemingNerfIndexPlugin
+    scheming_subfields_index=ckanext.scheming.plugins:SchemingSubfieldsIndexPlugin
     scheming_test_subclass=ckanext.scheming.tests.plugins:SchemingTestSubclass
     scheming_test_plugin=ckanext.scheming.tests.plugins:SchemingTestSchemaPlugin
     scheming_test_validation=ckanext.scheming.tests.plugins:SchemingTestValidationPlugin

--- a/test.ini
+++ b/test.ini
@@ -12,7 +12,7 @@ port = 5000
 use = config:../../src/ckan/test-core.ini
 
 ckan.plugins = scheming_datasets scheming_groups scheming_organizations
-               scheming_test_plugin scheming_nerf_index
+               scheming_test_plugin scheming_subfields_index
 scheming.dataset_schemas = ckanext.scheming:ckan_dataset.yaml
                            ckanext.scheming.tests:test_schema.json
 			   ckanext.scheming.tests:test_subfields.yaml


### PR DESCRIPTION
The `scheming_subfields_index` plugin will group the values of the same subfields in a text field that will make the values findable.
They are indexed as `extras_{field_name}__{key}`. `extras_*` is a dynamic `text` Solr field that will allow free-text search on these
values.

Added tests and updated the docs.

@wardi let me know what do you think and if you want to keep the `scheming_nerf_index` plugin or remove it in favour of this one.

Note: the test failure is a Python 2 one, support for which is removed in https://github.com/ckan/ckanext-scheming/pull/413