### PR TITLE
Don't store empty repeating subfields

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -397,15 +397,16 @@ def expand_form_composite(data, fieldnames):
         parts[1] = indexes[parts[1]]
         try:
             try:
-                comp[int(parts[1])]['-'.join(parts[2:])] = data[key]
-                del data[key]
+                if data[key]:
+                    comp[int(parts[1])]['-'.join(parts[2:])] = data[key]
             except IndexError:
                 comp.append({})
-                comp[int(parts[1])]['-'.join(parts[2:])] = data[key]
+                if data[key]:
+                    comp[int(parts[1])]['-'.join(parts[2:])] = data[key]
+            finally:
                 del data[key]
         except (IndexError, ValueError):
             pass  # best-effort only
-
 
 
 class SchemingGroupsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,

--- a/ckanext/scheming/tests/test_form.py
+++ b/ckanext/scheming/tests/test_form.py
@@ -327,6 +327,26 @@ class TestSubfieldDatasetForm(object):
         assert dataset["citation"] == [{'originator': ['mei', 'ahmed']}]
         assert dataset["contact_address"] == [{'address': 'anyplace'}]
 
+    def test_dataset_form_create_empty_subfields(self, app, sysadmin_env):
+        data = {"save": "", "_ckan_phase": 1}
+
+        data["name"] = "subfield_dataset_1"
+        data["citation-0-originator"] = ['mei', 'ahmed']
+        data["contact_address-0-address"] = 'anyplace'
+
+        data["publisher-0-name"] = ""
+        data["publisher-0-url"] = ""
+
+        url = '/test-subfields/new'
+        try:
+            app.post(url, environ_overrides=sysadmin_env, data=data, follow_redirects=False)
+        except TypeError:
+            app.post(url.encode('ascii'), params=data, extra_environ=sysadmin_env)
+
+        dataset = call_action("package_show", id="subfield_dataset_1")
+
+        assert "publisher" not in dataset
+
     def test_dataset_form_update(self, app, sysadmin_env):
         dataset = Dataset(
             type="test-subfields",

--- a/ckanext/scheming/tests/test_subfields.yaml
+++ b/ckanext/scheming/tests/test_subfields.yaml
@@ -44,6 +44,13 @@ dataset_fields:
   - field_name: country
     label: Country
 
+- field_name: publisher
+  label: Publisher
+  repeating_subfields:
+  - field_name: name
+    label: Name
+  - field_name: url
+    label: URL
 
 resource_fields:
 


### PR DESCRIPTION
When implementing repeating subfields without any mandatory subfields, if empty values are sent from the form an "empty" item is stored, with all its properties empties:

```
{
    "name": "test-dataset",
    "publisher": [
        {
            "email": "",
            "name": "",
            "type": "",
        }
    ]
}
```

The changes in `expand_form_composite()` fix the issue on the scheming side, preparing a `data_dict` with an empty list for that field:

```
{
    "name": "test-dataset",
    "publisher": []
}
```

Sadly, on the CKAN side the navl functions drop the field entirely (somewhere along [`make_full_schema`](https://github.com/ckan/ckan/blob/0628ead372cb17c96b145af0dcb4cb95b9cb67a8/ckan/lib/navl/dictization_functions.py#L150) and [`get_all_key_combinations`](https://github.com/ckan/ckan/blob/0628ead372cb17c96b145af0dcb4cb95b9cb67a8/ckan/lib/navl/dictization_functions.py#L126)) and it doesn't get stored as an extra, so it's missing from the resulting dataset dict.

```
{
    "name": "test-dataset",
}
```

@wardi Ideally we would want an empty list in the resulting dataset, but do you think a missing field is an improvement?