### PR TITLE
False is also a value

### DIFF
--- a/ckanext/scheming/templates/scheming/form_snippets/radio.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/radio.html
@@ -16,7 +16,7 @@
 {%- if field.get('sorted_choices') -%}
   {%- set options = options|sort(case_sensitive=false, attribute='text') -%}
 {%- endif -%}
-{%- if data[field.field_name] -%}
+{%- if data[field.field_name] is defined -%}
   {%- set option_selected = data[field.field_name]|string -%}
 {%- else -%}
   {%- set option_selected = None -%}

--- a/ckanext/scheming/templates/scheming/form_snippets/select.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/select.html
@@ -16,8 +16,10 @@
 {%- if field.get('sorted_choices') -%}
   {%- set options = options|sort(case_sensitive=false, attribute='text') -%}
 {%- endif -%}
-{%- if data[field.field_name] or data[field.field_name] is false -%}
+{%- if data[field.field_name] is defined -%}
   {%- set option_selected = data[field.field_name]|string -%}
+{%- elif field.default is defined -%}
+  {%- set option_selected = field.default|string -%}
 {%- else -%}
   {%- set option_selected = None -%}
 {%- endif -%}

--- a/ckanext/scheming/templates/scheming/form_snippets/select.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/select.html
@@ -16,7 +16,7 @@
 {%- if field.get('sorted_choices') -%}
   {%- set options = options|sort(case_sensitive=false, attribute='text') -%}
 {%- endif -%}
-{%- if data[field.field_name] -%}
+{%- if data[field.field_name] or data[field.field_name] is false -%}
   {%- set option_selected = data[field.field_name]|string -%}
 {%- else -%}
   {%- set option_selected = None -%}


### PR DESCRIPTION
In a field with boolean values like this

```yaml
- field_name: some_bool
  label: Some Bool
  required: false
  preset: select
  choices:
    - value: false
      label: "No"
    - value: true
      label: "Yes"
  validators: scheming_required boolean_validator
  output_validators: boolean_validator
```

and if the `false` value is selected, we didn't display anything in the _select_

This PR fixes those cases