### PR TITLE
Remove presets parsing cache

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -103,8 +103,6 @@ class _SchemingMixin(object):
 
     @staticmethod
     def _load_presets(config):
-        if _SchemingMixin._presets is not None:
-            return
 
         presets = reversed(
             config.get(


### PR DESCRIPTION
As it creates issues when loading plugins (e.g. in tests) See https://github.com/ckan/ckanext-scheming/issues/424

Fixes #424