### PR TITLE
Check if extras exist before converting

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -279,7 +279,7 @@ class SchemingDatasetsPlugin(p.SingletonPlugin, DefaultDatasetForm,
                 del data[(f,)]
 
         if action_type == 'show':
-            if composite_convert_fields:
+            if composite_convert_fields and data_dict.get("extras"):
                 for ex in data_dict['extras']:
                     if ex['key'] in composite_convert_fields:
                         data_dict[ex['key']] = json.loads(ex['value'])


### PR DESCRIPTION
In some situations like when validating an already validated dataset we might be missing the `extras` key.

See
https://github.com/ckan/ckanext-dcat/issues/305
https://github.com/ckan/ckan/pull/7571