### PR TITLE
is_organization is not set when organization created via UI

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -461,6 +461,8 @@ class SchemingOrganizationsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,
     SCHEMA_TYPE_FIELD = 'organization_type'
     UNSPECIFIED_GROUP_TYPE = 'organization'
 
+    is_organization = True
+
     @classmethod
     def _store_instance(cls, self):
         SchemingOrganizationsPlugin.instance = self

--- a/ckanext/scheming/tests/test_group_logic.py
+++ b/ckanext/scheming/tests/test_group_logic.py
@@ -1,7 +1,9 @@
 import pytest
 from ckanapi import LocalCKAN, NotFound
+import ckantoolkit as tk
 
 
+@pytest.mark.usefixtures("with_plugins")
 class TestGroupSchemaLists(object):
     def test_group_schema_list(self):
         lc = LocalCKAN("visitor")
@@ -34,3 +36,34 @@ class TestGroupSchemaLists(object):
         lc = LocalCKAN("visitor")
         with pytest.raises(NotFound):
             lc.action.scheming_organization_schema_show(type="elmo")
+
+    @pytest.mark.usefixtures("clean_db")
+    def test_is_organization_flag_set_via_web_form(
+            self,
+            faker,
+            app,
+            user,
+            api_token_factory,
+    ):
+        lc = LocalCKAN("visitor")
+        token = api_token_factory(user=user["name"])
+
+        group_name = faker.slug()
+        app.post(tk.url_for("theme.new"), data={
+            "name": group_name,
+        }, headers={
+            "Authorization": token["token"],
+        })
+
+        group = lc.action.group_show(id=group_name)
+        assert not group["is_organization"]
+
+        org_name = faker.slug()
+        app.post(tk.url_for("publisher.new"), data={
+            "name": org_name,
+        }, headers={
+            "Authorization": token["token"],
+        })
+
+        org = lc.action.organization_show(id=org_name)
+        assert org["is_organization"]


### PR DESCRIPTION
When creating an organization via WebUI, its `is_organization` flag depends on the value of the plugin's `is_organization` attribute. scheming_organizations doesn't have this attribute and custom organizations are saved as groups.

API uses different logic and is not affected by this issue, so the fix is required only for WebUI.