### PR TITLE
Fix validation for resource fields using preset datetime_tz

### DIFF
--- a/ckanext/scheming/tests/test_form.py
+++ b/ckanext/scheming/tests/test_form.py
@@ -470,3 +470,28 @@ class TestSubfieldResourceForm(object):
             {"frequency": '1y', "impact": 'A'},
             {"frequency": '1m', "impact": 'P'},
         ]
+
+    def test_resource_form_create_with_datetime_tz(self, app, sysadmin_env):
+        dataset = Dataset(type="test-schema")
+
+        url = h.url_for("test-schema_resource.new", id=dataset["id"])
+        if not url.startswith("/"):  # ckan < 2.9
+            url = "/dataset/new_resource/" + dataset["id"]
+
+        date = "2001-12-12"
+        time = "12:12"
+        tz = "UTC"
+
+        data = {
+            "id": "",
+            "save": "",
+            "datetime_tz_date": date,
+            "datetime_tz_time": time,
+            "datetime_tz_tz": tz,
+        }
+
+        _post_data(app, url, data, sysadmin_env)
+
+        dataset = call_action("package_show", id=dataset["id"])
+
+        assert dataset["resources"][0]["datetime_tz"] == f"{date}T{time}:00"


### PR DESCRIPTION
Validation for resource fields using the preset `datetime_tz` does not work. For datasets the validation works fine.

Let's say I have a field called `start_time` under a resource using the preset `datetime_tz`. Submitting this field (or more accurately the three fields for date, time and tz which it gets split into) from the form will result in three different fields being saved in the database under extras: `start_time_time`, `start_time_date` and `start_time_tz`. This happens because the keys for resources are different in the data passed from the form to the validator method compared to the keys used for datasets.

This pull request contains a fix to the validator as well as a test case. Please make suggestions or corrections if there is a better or more appropriate way to solve this issue.