### PR TITLE
Fix is_organization for custom organization type schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ckan/ckan-dev:${{ matrix.ckan-version }}
+      options: --user root
     services:
       solr:
         image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,3 +103,7 @@
 * fix for applying default org/group types
 * sync example dataset schemas, presets and templates with upstream ckan
   changes
+
+## 3.0.1
+
+* Fix `is_organization` for custom `organization_type` [#437](https://github.com/ckan/ckanext-scheming/pull/437)

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -460,6 +460,7 @@ class SchemingOrganizationsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,
     FALLBACK_OPTION = 'scheming.organization_fallback'
     SCHEMA_TYPE_FIELD = 'organization_type'
     UNSPECIFIED_GROUP_TYPE = 'organization'
+    is_organization = True
 
     @classmethod
     def _store_instance(cls, self):

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -460,6 +460,9 @@ class SchemingOrganizationsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,
     FALLBACK_OPTION = 'scheming.organization_fallback'
     SCHEMA_TYPE_FIELD = 'organization_type'
     UNSPECIFIED_GROUP_TYPE = 'organization'
+    # IGroupForm sets is_organization = False as a default value. 
+    # To properly use it to extend the Organization schema we need to set it to True.
+    # See: https://github.com/ckan/ckanext-scheming/pull/437
     is_organization = True
 
     @classmethod

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '3.0.0'
+version = '3.0.1'
 
 setup(
     name='ckanext-scheming',


### PR DESCRIPTION
CKAN core defines as default `is_organization = False` for the `IGroupForm`
https://github.com/ckan/ckan/blob/master/ckan/plugins/interfaces.py#L1352

Also, CKAN check is a group is an `organization` using this property
https://github.com/ckan/ckan/blob/master/ckan/lib/plugins.py#L223-L226

CKAN group index views at `ckan/views/group.index` uses this `is_organization` property.

If a custom `organization_type` is defined with a schema file through `ckanext-scheming` we need to ensure `is_organization = True`

This PR fixes this.

Also, to release 3.0.1 is proposed. A new tag `release-3.0.1` is required
Also, GitHub action fixed


