### PR TITLE
Fix preset display_snippets not rendered in group about page

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -162,7 +162,7 @@ class _GroupOrganizationMixin(object):
                 group_type = c.group_dict['type']
             else:
                 group_type = self.UNSPECIFIED_GROUP_TYPE
-        c.scheming_schema = self._schemas[group_type]
+        c.scheming_schema = self._expanded_schemas[group_type]
         c.group_type = group_type
         c.scheming_fields = c.scheming_schema['fields']
 


### PR DESCRIPTION
Use _expanded_schema fields when rendering group template.
Without the change presets were not loaded therefore wrong display_snippets were rendered.