### PR TITLE
Support for nested repeating subfields

### DIFF
--- a/ckanext/scheming/assets/js/scheming-repeating-subfields.js
+++ b/ckanext/scheming/assets/js/scheming-repeating-subfields.js
@@ -7,8 +7,8 @@ ckan.module('scheming-repeating-subfields', function($) {
       this.template = $template.html();
       $template.remove();
 
-      this.el.find('a[name="repeating-add"]').on("click", this._onCreateGroup);
-      this.el.on('click', 'a[name="repeating-remove"]', this._onRemoveGroup);
+      this.el.find('a[name="' + this.options.field_name + '-repeating-add"]').on("click", this._onCreateGroup);
+      this.el.on('click', 'a[name="' + this.options.field_name + '-repeating-remove"]', this._onRemoveGroup);
     },
 
     /**
@@ -29,11 +29,11 @@ ckan.module('scheming-repeating-subfields', function($) {
         var $last = this.el.find('.scheming-subfield-group').last();
         var group = ($last.data('groupIndex') + 1) || 0;
         var $copy = $(
-	    this.template.replace(/REPEATING-INDEX0/g, group)
-          .replace(/REPEATING-INDEX1/g, group + 1));
-        this.el.find('.scheming-repeating-subfields-group').append($copy);
+  	    this.template.replace(new RegExp(this.options.field_name + '-REPEATING-INDEX0', 'g'), group)
+          .replace(new RegExp(this.options.field_name + '-REPEATING-INDEX1', 'g'), group + 1));
+        this.el.find('[name="' + this.options.field_name + '-subfields-group"]').append($copy);
 
-	this.initializeModules($copy);
+      	this.initializeModules($copy);
         $copy.hide().show(100);
         $copy.find('input').first().focus();
         // hook for late init when required for rendering polyfills
@@ -46,9 +46,9 @@ ckan.module('scheming-repeating-subfields', function($) {
      */
     _onRemoveGroup: function(e) {
         var $curr = $(e.target).closest('.scheming-subfield-group');
-        var $body = $curr.find('.panel-body.fields-content');
-        var $button = $curr.find('.btn-repeating-remove');
-        var $removed = $curr.find('.panel-body.fields-removed-notice');
+        var $body = $curr.find('.panel-body.fields-content[data-field-name="' + this.options.field_name + '"]');
+        var $button = $curr.find('a[name="' + this.options.field_name + '-repeating-remove"]');
+        var $removed = $curr.find('.panel-body.fields-removed-notice[data-field-name="' + this.options.field_name + '"]');
         $button.hide();
         $removed.show(100);
         $body.hide(100, function() {

--- a/ckanext/scheming/templates/scheming/form_snippets/repeating_subfields.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/repeating_subfields.html
@@ -9,13 +9,13 @@
       {% block repeating_panel_header %}
         <header class="panel-heading">
           {% block field_removal_button%}
-            <a class="btn btn-danger btn-repeating-remove" name="repeating-remove" href="javascript:;"
+            <a class="btn btn-danger btn-repeating-remove" name="{{ field.field_name }}-repeating-remove" href="javascript:;"
               >{% block delete_button_text %}{{ _('Remove') }}{% endblock %}</a>
           {% endblock %}
           {{ h.scheming_language_text(field.repeating_label or field.label) }} {{ index1 }}
         </header>
       {% endblock %}
-      <div class="panel-body fields-content">
+      <div class="panel-body fields-content" data-field-name="{{ field.field_name }}">
         {% for subfield in field.repeating_subfields %}
           {% set sf = dict(
             subfield,
@@ -31,7 +31,7 @@
           -%}
         {% endfor %}
       </div>
-      <div class="panel-body fields-removed-notice" style="display:none">
+      <div class="panel-body fields-removed-notice" style="display:none" data-field-name="{{ field.field_name }}">
         {% block removal_text %}
           {% if 'id' in data %}
             {{ _('These fields have been removed, click update below to save your changes.') }}
@@ -54,7 +54,7 @@
   field.classes if 'classes' in field else ['control-medium'],
   is_required=h.scheming_field_required(field)) %}
     <div {{ form.attributes(field.get('form_attrs', {})) }}>
-      <fieldset name="scheming-repeating-subfields" class="scheming-fieldset" data-module="scheming-repeating-subfields">
+      <fieldset name="scheming-repeating-subfields" class="scheming-fieldset" data-module="scheming-repeating-subfields" data-module-field_name="{{ field.field_name }}">
         {% set alert_warning = h.scheming_language_text(field.form_alert_warning) %}
         {% if alert_warning %}
           <section class="alert alert-warning">
@@ -68,19 +68,19 @@
           {%- set group_count = field.form_blanks|default(1) -%}
         {%- endif -%}
 
-        <div class="scheming-repeating-subfields-group">
+        <div class="scheming-repeating-subfields-group" name="{{ field.field_name }}-subfields-group">
           {% for index in range(group_count) %}
             {{ repeating_panel(index, index + 1) }}
           {% endfor %}
         </div>
         <div class="control-medium">
-          {% block add_button %}<a href="javascript:;" name="repeating-add" class="btn btn-link"
+          {% block add_button %}<a href="javascript:;" name="{{ field.field_name }}-repeating-add" class="btn btn-link"
             >{% block add_button_text %}<i class="fa fa-plus" aria-hidden="true"></i> {{ _('Add') }}{% endblock %}</a>{% endblock %}
 
           {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
         </div>
 
-        <div name="repeating-template" style="display:none">{{ repeating_panel('REPEATING-INDEX0', 'REPEATING-INDEX1') }}</div>
+        <div name="repeating-template" style="display:none">{{ repeating_panel(field.field_name ~ '-REPEATING-INDEX0', field.field_name ~ '-REPEATING-INDEX1') }}</div>
       </fieldset>
     </div>
 {% endcall %}

--- a/ckanext/scheming/tests/test_form.py
+++ b/ckanext/scheming/tests/test_form.py
@@ -376,7 +376,6 @@ class TestSubfieldDatasetForm(object):
         ).attrs['value'] == 'ahmed'
 
         data = {"save": ""}
-        data["citation-0-originator"] = ['ling']
         data["citation-1-originator"] = ['umet']
         data["contact_address-0-address"] = 'home'
         data["name"] = dataset["name"]
@@ -387,7 +386,7 @@ class TestSubfieldDatasetForm(object):
 
         dataset = call_action("package_show", id=dataset["id"])
 
-        assert dataset["citation"] == [{'originator': ['ling']}, {'originator': ['umet']}]
+        assert dataset["citation"] == [{'originator': ['umet']}]
         assert dataset["contact_address"] == [{'address': 'home'}]
 
 

--- a/ckanext/scheming/tests/test_schema.json
+++ b/ckanext/scheming/tests/test_schema.json
@@ -82,6 +82,10 @@
       "label": "Example JSON",
       "field_name": "a_json_field",
       "preset": "json_object"
+    },
+    {
+      "field_name": "title-en",
+      "label": "A field with a dash"
     }
   ],
   "resource_fields": [

--- a/ckanext/scheming/tests/test_subfields.yaml
+++ b/ckanext/scheming/tests/test_subfields.yaml
@@ -43,6 +43,13 @@ dataset_fields:
   - field_name: country
     label: Country
 
+- field_name: contact_point
+  repeating_subfields:
+  - field_name: name
+  - field_name: address
+    repeating_subfields:
+    - field_name: country
+      required: true
 
 resource_fields:
 

--- a/ckanext/scheming/tests/test_validation.py
+++ b/ckanext/scheming/tests/test_validation.py
@@ -908,6 +908,20 @@ class TestSubfieldDatasetInvalid(object):
         else:
             raise AssertionError("ValidationError not raised")
 
+    def test_nested_subfields(self):
+        lc = LocalCKAN()
+
+        try:
+            lc.action.package_create(
+                type="test-subfields",
+                name="b_sf_1",
+                contact_point=[{"name": "name", "address": [{"other-field": True}]}]
+            )
+        except ValidationError as e:
+            assert e.error_dict["contact_point"][0]["address"][0]["country"] == ["Missing value"]
+        else:
+            raise AssertionError("ValidationError not raised")
+
 
 @pytest.mark.usefixtures("clean_db")
 class TestSubfieldResourceValid(object):


### PR DESCRIPTION
Much like #429, this adds support for nesting `repeating_subfields`.

This only exists because #429 doesn't apply cleanly anymore.

I'm aware of two limitations, both apparently imposed by CKAN's handling of nested schemas:
- A field with repeating subfields being the _only_ subfield of a field crashes, due to [this check](https://github.com/ckan/ckan/blob/823cafdb276e2255378fe2106b531abd9127eaf6/ckan/lib/navl/dictization_functions.py#L141).
  This seems like it should be a relatively rare case.

- Validators aren't applied to an empty leaf dictionary.
  I've worked around that in the validators test case, by adding a field there.
  This generally shouldn't be a problem when updating with a form, but I'm not sure how it would work with an API update.

This also fixes an issue, tested in the first commit, where deleting an instance of a `repeating_subfields` field would either reorder or remove entries of lexically later `repeating_subfields` fields. 

Closes #429  