### PR TITLE
Move Inline HTML Stuff to Classes

### DIFF
--- a/ckanext/scheming/assets/styles/scheming.css
+++ b/ckanext/scheming/assets/styles/scheming.css
@@ -55,3 +55,7 @@ fieldset.checkboxes label input {
 .scheming-pages-dynamic-width{
   width: attr(data-width, 100)%;
 }
+
+.d-none-soft{
+  display: none;
+}

--- a/ckanext/scheming/assets/styles/scheming.css
+++ b/ckanext/scheming/assets/styles/scheming.css
@@ -39,3 +39,19 @@ a.btn.btn-multiple-remove {
 .radio-group label {
   font-weight: normal;
 }
+
+fieldset.checkboxes label {
+  font-weight: normal;
+  display: block;
+}
+fieldset.checkboxes label:after {
+  content: none;
+}
+fieldset.checkboxes label input {
+  width: auto;
+  top: 0;
+}
+
+.scheming-pages-dynamic-width{
+  width: attr(data-width, 100)%;
+}

--- a/ckanext/scheming/templates/scheming/display_snippets/link.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/link.html
@@ -1,1 +1,1 @@
-{{ h.link_to(data[field.field_name], data[field.field_name], rel=field.display_property, target='_blank') }}
+{{ h.link_to(data[field.field_name], data[field.field_name], rel=field.display_property ~ 'noopener noreferrer', target='_blank') }}

--- a/ckanext/scheming/templates/scheming/form_snippets/multiple_checkbox.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/multiple_checkbox.html
@@ -1,19 +1,5 @@
 {% import 'macros/form.html' as form %}
 
-<style>
-fieldset.checkboxes label {
-    font-weight: normal;
-    display: block;
-}
-fieldset.checkboxes label:after {
-    content: none;
-}
-fieldset.checkboxes label input {
-    width: auto;
-    top: 0;
-}
-</style>
-
 {%- call form.input_block(
     label=h.scheming_language_text(field.label),
     classes=field.classes if 'classes' in field else ['control-medium'],

--- a/ckanext/scheming/templates/scheming/form_snippets/multiple_select.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/multiple_select.html
@@ -22,11 +22,10 @@
   {%- endif -%}
   <select multiple
       size="{{ field.get('select_size', field.choices|length) }}"
-      style="display: block"
       id="field-{{ field.field_name }}"
       name="{{ field.field_name }}"
       {{ form.attributes(dict(
-        {"class": "form-control"}, **field.get('form_select_attrs', {}))) }}>
+        {"class": "form-control d-block"}, **field.get('form_select_attrs', {}))) }}>
     {%- for val, label in choices -%}
       <option id="field-{{ field.field_name }}-{{ val }}"
           value="{{ val }}"

--- a/ckanext/scheming/templates/scheming/form_snippets/repeating_subfields.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/repeating_subfields.html
@@ -31,7 +31,7 @@
           -%}
         {% endfor %}
       </div>
-      <div class="panel-body fields-removed-notice" style="display:none">
+      <div class="panel-body fields-removed-notice d-none-soft">
         {% block removal_text %}
           {% if 'id' in data %}
             {{ _('These fields have been removed, click update below to save your changes.') }}
@@ -80,7 +80,7 @@
           {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
         </div>
 
-        <div name="repeating-template" style="display:none">{{ repeating_panel('REPEATING-INDEX0', 'REPEATING-INDEX1') }}</div>
+        <div name="repeating-template" class="d-none-soft">{{ repeating_panel('REPEATING-INDEX0', 'REPEATING-INDEX1') }}</div>
       </fieldset>
     </div>
 {% endcall %}

--- a/ckanext/scheming/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/package_form.html
@@ -9,9 +9,9 @@
       {%- for p in pages -%}
         <li class="{{
           'first ' if loop.first else ''}}{{
-          'active ' if loop.index == active_page else '' }}"
-          style="width:{{ 100 / (loop.length + (0 if form_style == 'edit' else 1)) }}%">
-          <span class="highlight" style="padding-right:0">{% if loop.index < active_page
+          'active ' if loop.index == active_page else '' }} scheming-pages-dynamic-width"
+          data-width="{{- 100 / (loop.length + (0 if form_style == 'edit' else 1)) -}}">
+          <span class="highlight pr-0">{% if loop.index < active_page
               or (form_style == 'edit' and loop.index != active_page)
             %}<a href="{{
               h.url_for(dataset_type +
@@ -35,7 +35,7 @@
         </li>
       {%- endfor -%}
       {%- if form_style != 'edit' -%}
-        <li class="last {{ s2 }}" style="width:{{ 100 / (pages | length + 1) }}%">
+        <li class="last {{ s2 }} scheming-pages-dynamic-width" data-width="{{- 100 / (pages | length + 1) -}}">
           {% if s2 != 'complete' %}
             <span class="highlight">{{ _('Add data') }}</span>
           {% else %}

--- a/ckanext/scheming/templates/scheming/package/snippets/resource_form.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/resource_form.html
@@ -7,9 +7,9 @@
     <ol class="stages stage-1">
       {%- for p in pages -%}
         <li class="{{
-          'first ' if loop.first else ''}}"
-          style="width:{{ 100 / (loop.length + 1) }}%">
-          <span class="highlight" style="padding-right:0"><a href="{{
+          'first ' if loop.first else ''}} scheming-pages-dynamic-width"
+          data-width="{{- 100 / (loop.length + 1) -}}">
+          <span class="highlight pr-0"><a href="{{
               h.url_for(dataset_type + '.scheming_new_page',
                 package_type=dataset_type,
                 id=pkg_name,
@@ -28,7 +28,7 @@
           </span>
         </li>
       {%- endfor -%}
-      <li class="last active" style="width:{{ 100 / (pages | length + 1) }}%">
+      <li class="last active scheming-pages-dynamic-width" data-width="{{- 100 / (pages | length + 1) -}}">
         <span class="highlight">{{ _('Add data') }}</span>
       </li>
     </ol>


### PR DESCRIPTION
@wardi regarding the VA scan, this would be required for users using a Content-Security-Policy header without `unsafe-inline` in it. Also included the `noopener noreferrer` for link outputs.