### PR TITLE
feat: Adding additional templates for Repeating fields

### DIFF
--- a/ckanext/scheming/templates/scheming/form_snippets/collapse_repeating_fields.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/collapse_repeating_fields.html
@@ -1,0 +1,93 @@
+{# A complex field with repeating sub-fields #}
+
+{% include 'scheming/snippets/subfields_asset.html' %}
+{% import 'macros/form.html' as form %}
+
+{% macro repeating_panel(index, index1) %}
+  <div class="scheming-subfield-group" data-field="{{ field.field_name }}" data-group-index="{{ index }}">
+    <div class="panel panel-default">
+      {% block repeating_panel_header %}
+        <header class="panel-heading">
+          {% block field_removal_button%}
+            <a class="btn btn-danger btn-repeating-remove" name="repeating-remove" href="javascript:;"
+              >{% block delete_button_text %}{{ _('Remove') }}{% endblock %}</a>
+          {% endblock %}
+          {{ h.scheming_language_text(field.repeating_label or field.label) }} {{ index1 }}
+        </header>
+      {% endblock %}
+      <div class="panel-body fields-content">
+        {% for subfield in field.repeating_subfields %}
+          {% set sf = dict(
+            subfield,
+            field_name=field.field_name ~ '-' ~ index ~ '-' ~ subfield.field_name)
+          %}
+          {%- snippet 'scheming/snippets/form_field.html',
+            field=sf,
+            data=flat,
+            errors=flaterr,
+            licenses=licenses,
+            entity_type=entity_type,
+            object_type=object_type
+          -%}
+        {% endfor %}
+      </div>
+      <div class="panel-body fields-removed-notice" style="display:none">
+        {% block removal_text %}
+          {% if 'id' in data %}
+            {{ _('These fields have been removed, click update below to save your changes.') }}
+          {% else %}
+            {{ _('These fields have been removed.') }}
+          {% endif %}
+        {% endblock %}
+      </div>
+    </div>
+  </div>
+{% endmacro %}
+
+{% set flat = h.scheming_flatten_subfield(field, data) %}
+{% set flaterr = h.scheming_flatten_subfield(field, errors) %}
+
+
+<div class="accordion mb-3">
+  <div class="accordion-item">
+      <h3 class="accordion-header" id="accordion-{{ field.field_name }}-heading">
+          <button class="accordion-button collapsed fw-bold" type="button" data-bs-toggle="collapse" data-bs-target="#accordion-{{ field.field_name }}" aria-expanded="false" aria-controls="accordion-{{ field.field_name }}">
+              {{ h.scheming_language_text(field.label) or field.field_name }}
+          </button>
+      </h3>
+      <div id="accordion-{{ field.field_name }}" class="accordion-collapse collapse" aria-labelledby="accordion-{{ field.field_name }}-heading">
+          <div class="accordion-body">
+            <div {{ form.attributes(field.get('form_attrs', {})) }}>
+              <fieldset name="scheming-repeating-subfields" class="scheming-fieldset" data-module="scheming-repeating-subfields">
+                {% set alert_warning = h.scheming_language_text(field.form_alert_warning) %}
+                {% if alert_warning %}
+                  <section class="alert alert-warning">
+                    {{ alert_warning|safe }}
+                  </section>
+                {% endif %}
+
+                {%- set group_data = data[field.field_name] -%}
+                {%- set group_count = group_data|length -%}
+                {%- if not group_count and 'id' not in data -%}
+                  {%- set group_count = field.form_blanks|default(1) -%}
+                {%- endif -%}
+
+                <div class="scheming-repeating-subfields-group">
+                  {% for index in range(group_count) %}
+                    {{ repeating_panel(index, index + 1) }}
+                  {% endfor %}
+                </div>
+                <div class="control-medium">
+                  {% block add_button %}<a href="javascript:;" name="repeating-add" class="btn btn-link"
+                    >{% block add_button_text %}<i class="fa fa-plus" aria-hidden="true"></i> {{ _('Add') }}{% endblock %}</a>{% endblock %}
+
+                  {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+                </div>
+
+                <div name="repeating-template" style="display:none">{{ repeating_panel('REPEATING-INDEX0', 'REPEATING-INDEX1') }}</div>
+              </fieldset>
+            </div>
+          </div>
+      </div>
+  </div>
+</div>

--- a/ckanext/scheming/templates/scheming/form_snippets/collapse_repeating_fields_grid.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/collapse_repeating_fields_grid.html
@@ -1,0 +1,92 @@
+{# A complex field with repeating sub-fields #}
+
+{% include 'scheming/snippets/subfields_asset.html' %}
+{% import 'macros/form.html' as form %}
+
+{% macro repeating_panel(index, index1) %}
+  <div class="scheming-subfield-group {% if field.col_class %}{{ field.col_class }}{% else %}col-md-6{% endif %}" data-field="{{ field.field_name }}" data-group-index="{{ index }}">
+    <div class="panel panel-default">
+      {% block repeating_panel_header %}
+        <header class="panel-heading">
+          {% block field_removal_button%}
+            <a class="btn btn-danger btn-repeating-remove" name="repeating-remove" href="javascript:;"
+              >{% block delete_button_text %}{{ _('Remove') }}{% endblock %}</a>
+          {% endblock %}
+        </header>
+      {% endblock %}
+      <div class="panel-body fields-content">
+        {% for subfield in field.repeating_subfields %}
+          {% set sf = dict(
+            subfield,
+            field_name=field.field_name ~ '-' ~ index ~ '-' ~ subfield.field_name)
+          %}
+          {%- snippet 'scheming/snippets/form_field.html',
+            field=sf,
+            data=flat,
+            errors=flaterr,
+            licenses=licenses,
+            entity_type=entity_type,
+            object_type=object_type
+          -%}
+        {% endfor %}
+      </div>
+      <div class="panel-body fields-removed-notice" style="display:none">
+        {% block removal_text %}
+          {% if 'id' in data %}
+            {{ _('These fields have been removed, click update below to save your changes.') }}
+          {% else %}
+            {{ _('These fields have been removed.') }}
+          {% endif %}
+        {% endblock %}
+      </div>
+    </div>
+  </div>
+{% endmacro %}
+
+{% set flat = h.scheming_flatten_subfield(field, data) %}
+{% set flaterr = h.scheming_flatten_subfield(field, errors) %}
+
+
+<div class="accordion mb-3">
+  <div class="accordion-item">
+      <h3 class="accordion-header" id="accordion-{{ field.field_name }}-heading">
+          <button class="accordion-button collapsed fw-bold" type="button" data-bs-toggle="collapse" data-bs-target="#accordion-{{ field.field_name }}" aria-expanded="false" aria-controls="accordion-{{ field.field_name }}">
+              {{ h.scheming_language_text(field.label) or field.field_name }}
+          </button>
+      </h3>
+      <div id="accordion-{{ field.field_name }}" class="accordion-collapse collapse" aria-labelledby="accordion-{{ field.field_name }}-heading">
+          <div class="accordion-body">
+            <div {{ form.attributes(field.get('form_attrs', {})) }}>
+              <fieldset name="scheming-repeating-subfields" class="scheming-fieldset" data-module="scheming-repeating-subfields">
+                {% set alert_warning = h.scheming_language_text(field.form_alert_warning) %}
+                {% if alert_warning %}
+                  <section class="alert alert-warning">
+                    {{ alert_warning|safe }}
+                  </section>
+                {% endif %}
+
+                {%- set group_data = data[field.field_name] -%}
+                {%- set group_count = group_data|length -%}
+                {%- if not group_count and 'id' not in data -%}
+                  {%- set group_count = field.form_blanks|default(1) -%}
+                {%- endif -%}
+
+                <div class="scheming-repeating-subfields-group row">
+                  {% for index in range(group_count) %}
+                    {{ repeating_panel(index, index + 1) }}
+                  {% endfor %}
+                </div>
+                <div class="control-medium">
+                  {% block add_button %}<a href="javascript:;" name="repeating-add" class="btn btn-link"
+                    >{% block add_button_text %}<i class="fa fa-plus" aria-hidden="true"></i> {{ _('Add') }}{% endblock %}</a>{% endblock %}
+
+                  {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+                </div>
+
+                <div name="repeating-template" style="display:none">{{ repeating_panel('REPEATING-INDEX0', 'REPEATING-INDEX1') }}</div>
+              </fieldset>
+            </div>
+          </div>
+      </div>
+  </div>
+</div>


### PR DESCRIPTION
Out of the box, the template for Repeating fields is straightforward, but the main issue with it is the space it takes, especially where there more the 2 values or fieldset of multiple fields in it.

This PR adds two additional options for displaying Repeating Fields:

1. Accordion where the fields are stored
2. Accordion, but with additional ability to provide grid layout for the fields to save space.


https://github.com/user-attachments/assets/fb78f5d6-da56-4963-8125-88342bcca825

I understand that having 3 different templates is hard to maintain, so I can suggest combaine those into 1 with additional configuration from the schema itself.
Maybe you have other suggestions that I can work on?