### PR TITLE
Add CKAN v2.12 support to upload snippet

### DIFF
--- a/ckanext/scheming/templates/scheming/form_snippets/organization_upload.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/organization_upload.html
@@ -9,7 +9,7 @@
     is_upload_enabled=h.uploads_enabled("group") if h.check_ckan_version("2.12") else h.uploads_enabled(),
     is_url=is_url,
     is_upload=is_upload
-)
+    )
 }}
 
 {# image_upload macro doesn't support call #}

--- a/ckanext/scheming/templates/scheming/form_snippets/organization_upload.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/organization_upload.html
@@ -6,10 +6,10 @@
 {{ form.image_upload(
     data,
     errors,
-    is_upload_enabled=h.uploads_enabled(),
+    is_upload_enabled=h.uploads_enabled("group") if h.check_ckan_version("2.12") else h.uploads_enabled(),
     is_url=is_url,
     is_upload=is_upload
-    ) 
+)
 }}
 
 {# image_upload macro doesn't support call #}

--- a/ckanext/scheming/templates/scheming/form_snippets/upload.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/upload.html
@@ -13,7 +13,7 @@
     upload_label=h.scheming_language_text(field.upload_label),
     url_label=h.scheming_language_text(field.label),
     placeholder=field.form_placeholder
-)
+    )
 }}
 {# image_upload macro doesn't support call #}
 {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}

--- a/ckanext/scheming/templates/scheming/form_snippets/upload.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/upload.html
@@ -7,13 +7,13 @@
     field_url=field.field_name,
     field_upload=field.upload_field,
     field_clear=field.upload_clear,
-    is_upload_enabled=h.uploads_enabled(),
+    is_upload_enabled=h.uploads_enabled("resource") if h.check_ckan_version("2.12") else h.uploads_enabled(),
     is_url=data[field.field_name] and not is_upload,
     is_upload=is_upload,
     upload_label=h.scheming_language_text(field.upload_label),
     url_label=h.scheming_language_text(field.label),
     placeholder=field.form_placeholder
-    )
+)
 }}
 {# image_upload macro doesn't support call #}
 {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}


### PR DESCRIPTION
`h.uploads_enabled` expects type of upload(`resource`, `admin`, `user`, `group`) in CKAN v2.12.